### PR TITLE
feat(legacy): add --excluded-services option for log forwarding integrations

### DIFF
--- a/legacy/src/Command/Integration/IntegrationCommandBase.php
+++ b/legacy/src/Command/Integration/IntegrationCommandBase.php
@@ -191,6 +191,15 @@ abstract class IntegrationCommandBase extends CommandBase
      */
     private function getFields(): array
     {
+        $logForwardingTypes = [
+            'httplog',
+            'newrelic',
+            'splunk',
+            'sumologic',
+            'syslog',
+            'otlplog',
+        ];
+
         $allSupportedTypes = [
             'bitbucket',
             'bitbucket_server',
@@ -201,13 +210,8 @@ abstract class IntegrationCommandBase extends CommandBase
             'health.pagerduty',
             'health.slack',
             'health.webhook',
-            'httplog',
             'script',
-            'newrelic',
-            'splunk',
-            'sumologic',
-            'syslog',
-            'otlplog',
+            ...$logForwardingTypes,
         ];
 
         return [
@@ -606,14 +610,7 @@ abstract class IntegrationCommandBase extends CommandBase
                 'required' => false,
             ]),
             'tls_verify' => new BooleanField('Verify TLS', [
-                'conditions' => ['type' => [
-                    'httplog',
-                    'newrelic',
-                    'splunk',
-                    'sumologic',
-                    'syslog',
-                    'otlplog',
-                ]],
+                'conditions' => ['type' => $logForwardingTypes],
                 'description' => 'Whether HTTPS certificate verification should be enabled (recommended)',
                 'questionLine' => 'Should HTTPS certificate verification be enabled (recommended)',
                 'default' => true,
@@ -649,6 +646,14 @@ abstract class IntegrationCommandBase extends CommandBase
                     }
                     return true;
                 },
+            ]),
+            'excluded_services' => new ArrayField('Excluded services', [
+                'optionName' => 'excluded-services',
+                'conditions' => ['type' => $logForwardingTypes],
+                'default' => [],
+                'description' => 'A list of services to exclude from the log forwarding.',
+                'required' => false,
+                'avoidQuestion' => true,
             ]),
         ];
     }

--- a/legacy/tests/Command/Integration/IntegrationCommandBaseTest.php
+++ b/legacy/tests/Command/Integration/IntegrationCommandBaseTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Platformsh\Cli\Tests\Command\Integration;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Platformsh\Cli\Command\Integration\IntegrationAddCommand;
+use Platformsh\ConsoleForm\Field\ArrayField;
+
+#[Group('commands')]
+class IntegrationCommandBaseTest extends TestCase
+{
+    /** @var array<string, \Platformsh\ConsoleForm\Field\Field> */
+    private array $fields;
+
+    protected function setUp(): void
+    {
+        $command = new IntegrationAddCommand(
+            $this->createMock(\Platformsh\Cli\Service\ActivityMonitor::class),
+            $this->createMock(\Platformsh\Cli\Service\QuestionHelper::class),
+            $this->createMock(\Platformsh\Cli\Selector\Selector::class),
+        );
+        $ref = new \ReflectionMethod($command, 'getFields');
+        $ref->setAccessible(true);
+        $this->fields = $ref->invoke($command);
+    }
+
+    public function testExcludedServicesFieldExists(): void
+    {
+        $this->assertArrayHasKey('excluded_services', $this->fields);
+    }
+
+    public function testExcludedServicesFieldIsArrayField(): void
+    {
+        $this->assertInstanceOf(ArrayField::class, $this->fields['excluded_services']);
+    }
+
+    public function testExcludedServicesFieldOptionName(): void
+    {
+        $this->assertSame('excluded-services', $this->fields['excluded_services']->getOptionName());
+    }
+
+    public function testExcludedServicesFieldNotRequired(): void
+    {
+        $this->assertFalse($this->fields['excluded_services']->isRequired());
+    }
+
+    public function testExcludedServicesFieldConditions(): void
+    {
+        $conditions = $this->fields['excluded_services']->getConditions();
+        $this->assertArrayHasKey('type', $conditions);
+        $expected = ['httplog', 'newrelic', 'splunk', 'sumologic', 'syslog', 'otlplog'];
+        $this->assertSame($expected, $conditions['type']);
+    }
+
+    public function testExcludedServicesFieldIncludedForLogForwardingTypes(): void
+    {
+        $typeField = $this->fields['type'];
+        $conditionValues = $this->fields['excluded_services']->getConditions()['type'];
+        foreach ($conditionValues as $type) {
+            $this->assertTrue(
+                $typeField->matchesCondition($type, $conditionValues),
+                "Expected excluded_services to be included for type '$type'",
+            );
+        }
+    }
+
+    public function testExcludedServicesFieldExcludedForNonLogForwardingTypes(): void
+    {
+        $typeField = $this->fields['type'];
+        $conditionValues = $this->fields['excluded_services']->getConditions()['type'];
+        $nonLogTypes = [
+            'bitbucket',
+            'bitbucket_server',
+            'github',
+            'gitlab',
+            'webhook',
+            'health.email',
+            'health.pagerduty',
+            'health.slack',
+            'health.webhook',
+            'script',
+        ];
+        foreach ($nonLogTypes as $type) {
+            $this->assertFalse(
+                $typeField->matchesCondition($type, $conditionValues),
+                "Expected excluded_services to be excluded for type '$type'",
+            );
+        }
+    }
+}


### PR DESCRIPTION
Allow users to exclude specific apps/services from log forwarding when adding or updating httplog, newrelic, splunk, sumologic, syslog, and otlplog integrations.