### PR TITLE
feat(operation:run): add --parameter option for runtime operations

### DIFF
--- a/legacy/src/Command/RuntimeOperation/RunCommand.php
+++ b/legacy/src/Command/RuntimeOperation/RunCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Platformsh\Cli\Command\RuntimeOperation;
 
+use Platformsh\Cli\Console\ArrayArgument;
 use Platformsh\Cli\Selector\Selector;
 use Platformsh\Cli\Selector\SelectorConfig;
 use Platformsh\Cli\Service\ActivityMonitor;
@@ -39,7 +40,9 @@ class RunCommand extends CommandBase
         $this->selector->addAppOption($this->getDefinition());
         $this->addCompleter($this->selector);
         $this->addOption('worker', null, InputOption::VALUE_REQUIRED, 'A worker name');
+        $this->addOption('parameter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A parameter for the operation. ' . ArrayArgument::SPLIT_HELP);
         $this->activityMonitor->addWaitOptions($this->getDefinition());
+        $this->addExample('Run the "clear-cache" operation with parameters', 'clear-cache --app myapp --parameter param1 --parameter param2');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -123,7 +126,8 @@ class RunCommand extends CommandBase
         }
 
         try {
-            $result = $deployment->execRuntimeOperation($operationName, $appName);
+            $parameters = ArrayArgument::getOption($input, 'parameter');
+            $result = $deployment->execRuntimeOperation($operationName, $appName, $parameters);
         } catch (OperationUnavailableException) {
             throw new ApiFeatureMissingException('This project does not support runtime operations.');
         }


### PR DESCRIPTION
Allow passing parameters to runtime operations via the --parameter option, which accepts repeated values or comma-separated lists.