### PR TITLE
fix: handle v-prefix in installer.sh for GoReleaser asset filenames

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -284,7 +284,7 @@ check_version() {
     esac
 
     # The version without the v prefix (for asset filenames).
-    version=$(echo "$tag" | sed 's/^v//')
+    version=${tag#v}
 
     if [ -z "$version" ]; then
         output "  [ ] ERROR: Could not determine CLI version" "error"

--- a/installer.sh
+++ b/installer.sh
@@ -286,6 +286,11 @@ check_version() {
     # The version without the v prefix (for asset filenames).
     version=$(echo "$tag" | sed 's/^v//')
 
+    if [ -z "$version" ]; then
+        output "  [ ] ERROR: Could not determine CLI version" "error"
+        exit_with_error
+    fi
+
     if [ -z "${VERSION}" ]; then
         output "  [*] No version specified, using latest ($version)" "success"
     else

--- a/installer.sh
+++ b/installer.sh
@@ -272,7 +272,7 @@ check_ca_certificates() {
 
 check_version() {
     if [ -z "${VERSION}" ]; then
-        tag=$(curl -I https://github.com/upsun/cli/releases/latest 2>/dev/null | awk -F/ -v RS='\r\n' '/upsun.cli.releases.tag/ {printf "%s", $NF}')
+        tag=$(github_curl https://api.github.com/repos/upsun/cli/releases/latest 2>/dev/null | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
     else
         tag=${VERSION}
     fi

--- a/installer.sh
+++ b/installer.sh
@@ -39,6 +39,7 @@ footer_notes=""
 has_sudo=""
 kernel=""
 machine=""
+tag=""
 version=""
 package="upsun-cli"
 docs_url="https://docs.upsun.com"
@@ -271,11 +272,24 @@ check_ca_certificates() {
 
 check_version() {
     if [ -z "${VERSION}" ]; then
-        version=$(curl -I https://github.com/upsun/cli/releases/latest 2>/dev/null | awk -F/ -v RS='\r\n' '/upsun.cli.releases.tag/ {printf "%s", $NF}')
+        tag=$(curl -I https://github.com/upsun/cli/releases/latest 2>/dev/null | awk -F/ -v RS='\r\n' '/upsun.cli.releases.tag/ {printf "%s", $NF}')
+    else
+        tag=${VERSION}
+    fi
+
+    # Ensure the tag has the v prefix (for GitHub release URLs).
+    case "$tag" in
+        v*) ;;
+        *) tag="v${tag}" ;;
+    esac
+
+    # The version without the v prefix (for asset filenames).
+    version=$(echo "$tag" | sed 's/^v//')
+
+    if [ -z "${VERSION}" ]; then
         output "  [*] No version specified, using latest ($version)" "success"
     else
-        output "  [*] Version ${VERSION} specified" "success"
-        version=${VERSION}
+        output "  [*] Version ${version} specified" "success"
     fi
 }
 
@@ -608,7 +622,7 @@ install_raw() {
     # Start downloading the right version
     output "\nDownloading the $vendor_name CLI" "heading"
 
-    url="${URL}/${version}/${binary}_${version}_${kernel}_${machine}.tar.gz"
+    url="${URL}/${tag}/${binary}_${version}_${kernel}_${machine}.tar.gz"
     output "  Downloading ${url}";
     tmp_dir=$(mktemp -d)
     tmp_name="$binary-"$(date +"%s")


### PR DESCRIPTION
## Summary

GoReleaser strips the `v` prefix from asset filenames but keeps it in the tag/release URL path. The installer was using the raw tag name for both, producing URLs like:

```
.../download/v5.10.0-alpha1/upsun_v5.10.0-alpha1_linux_amd64.tar.gz
                             ^^^ wrong, actual file has no v
```

- Introduce separate `tag` (v-prefixed, for release path) and `version` (no prefix, for filenames) variables
- Normalize user-supplied `VERSION` to handle both `5.10.0` and `v5.10.0`

Found during the first pre-release on the new repo (`v5.10.0-alpha1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)