### PR TITLE
fix: restore version ldflag for GoReleaser builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       - platformsh
     ldflags:
       - -s -w
+      - -X "github.com/upsun/cli/internal/config.Version={{.Version}}"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
   - binary: platform
@@ -40,6 +41,7 @@ builds:
       - platformsh
     ldflags:
       - -s -w
+      - -X "github.com/upsun/cli/internal/config.Version={{.Version}}"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
 
@@ -58,6 +60,7 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
+      - -X "github.com/upsun/cli/internal/config.Version={{.Version}}"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
   - binary: upsun
@@ -71,6 +74,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
+      - -X "github.com/upsun/cli/internal/config.Version={{.Version}}"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
 


### PR DESCRIPTION
## Summary

Commit 73a97c77 removed version ldflags in favor of `runtime/debug.ReadBuildInfo()`. This doesn't work because the module path (`github.com/upsun/cli`) lacks the `/v5` suffix required for Go to associate `v5.x.x` tags with the module. The result: binaries report `v0.0.0-<pseudo-version>` instead of the actual release version.

- Restore `-X internal/config.Version={{.Version}}` ldflag to all four build entries
- The `debug.ReadBuildInfo()` fallback in `version.go` remains for `go install` users

🤖 Generated with [Claude Code](https://claude.com/claude-code)