### PR TITLE
fix: use GORELEASER_CURRENT_TAG for RC release detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ else
 	GORELEASER_ID = $(FLAVOR)
 endif
 
-VERSION := $(shell git describe --always)
+# Use GORELEASER_CURRENT_TAG if set (from GitHub Actions), otherwise derive from git
+VERSION ?= $(or $(GORELEASER_CURRENT_TAG),$(shell git describe --tags --always 2>/dev/null || echo "0.0.0-dev"))
 
 # Tooling versions
 GORELEASER_VERSION=v2.12.0

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ else
 endif
 
 # Use GORELEASER_CURRENT_TAG if set (from GitHub Actions), otherwise derive from git
-VERSION ?= $(or $(GORELEASER_CURRENT_TAG),$(shell git describe --tags --always 2>/dev/null || echo "0.0.0-dev"))
+ifeq ($(origin VERSION), undefined)
+VERSION := $(or $(GORELEASER_CURRENT_TAG),$(shell git describe --tags --always 2>/dev/null || echo "0.0.0-dev"))
+endif
 
 # Tooling versions
 GORELEASER_VERSION=v2.12.0

--- a/cloudsmith.sh
+++ b/cloudsmith.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 # Upload Platform.sh packages
 cloudsmith push deb platformsh/cli/any-distro/any-version dist/platformsh-cli_${VERSION}_linux_arm64.deb
 cloudsmith push deb platformsh/cli/any-distro/any-version dist/platformsh-cli_${VERSION}_linux_amd64.deb

--- a/cloudsmith.sh
+++ b/cloudsmith.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${VERSION:-}" ]]; then
+  echo "Error: VERSION environment variable is not set. Please set VERSION (e.g., '1.2.3') before running cloudsmith.sh." >&2
+  exit 1
+fi
 # Upload Platform.sh packages
 cloudsmith push deb platformsh/cli/any-distro/any-version dist/platformsh-cli_${VERSION}_linux_arm64.deb
 cloudsmith push deb platformsh/cli/any-distro/any-version dist/platformsh-cli_${VERSION}_linux_amd64.deb


### PR DESCRIPTION
  ### Summary                                                                                                                                                         
                                                            
  Fixes RC release builds by ensuring the Makefile correctly detects pre-release versions and skips Cloudsmith uploads.                                           
                                                            
 ### Changes

  - Updated Makefile to use GORELEASER_CURRENT_TAG (set by GitHub Actions) instead of git describe --always, which was returning commit hashes instead of tag
  names in shallow checkouts
  - Added shebang and error handling to cloudsmith.sh for safety

###  Result

RC releases (e.g., v5.10.0-rc1) now properly skip Cloudsmith uploads instead of failing when attempting to run the upload script.