### PR TITLE
fix: restore BuiltBy=goreleaser ldflag in GoReleaser configs

### DIFF
--- a/.goreleaser.vendor.yaml.tpl
+++ b/.goreleaser.vendor.yaml.tpl
@@ -25,6 +25,7 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
+      - -X "github.com/upsun/cli/internal/config.BuiltBy=goreleaser"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
   - binary: ${VENDOR_BINARY}
@@ -40,6 +41,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
+      - -X "github.com/upsun/cli/internal/config.BuiltBy=goreleaser"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,7 @@ builds:
     ldflags:
       - -s -w
       - -X "github.com/upsun/cli/internal/config.Version={{.Version}}"
+      - -X "github.com/upsun/cli/internal/config.BuiltBy=goreleaser"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
   - binary: platform
@@ -42,6 +43,7 @@ builds:
     ldflags:
       - -s -w
       - -X "github.com/upsun/cli/internal/config.Version={{.Version}}"
+      - -X "github.com/upsun/cli/internal/config.BuiltBy=goreleaser"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
 
@@ -61,6 +63,7 @@ builds:
     ldflags:
       - -s -w
       - -X "github.com/upsun/cli/internal/config.Version={{.Version}}"
+      - -X "github.com/upsun/cli/internal/config.BuiltBy=goreleaser"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
   - binary: upsun
@@ -75,6 +78,7 @@ builds:
     ldflags:
       - -s -w
       - -X "github.com/upsun/cli/internal/config.Version={{.Version}}"
+      - -X "github.com/upsun/cli/internal/config.BuiltBy=goreleaser"
       - -X "github.com/upsun/cli/internal/legacy.PHPVersion={{.Env.PHP_VERSION}}"
     main: ./cmd/platform
 


### PR DESCRIPTION
## Summary

- Restore the `-X "...BuiltBy=goreleaser"` ldflag that was removed in 73a97c77
- Without it, GoReleaser-built binaries report "built ... by local" instead of "built ... by goreleaser"
- Added to all 4 build entries in `.goreleaser.yaml` and both in `.goreleaser.vendor.yaml.tpl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)