### PR TITLE
refactor: remove LegacyCLIVersion from codebase

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -27,11 +27,6 @@ func newVersionCommand(cnf *config.Config) *cobra.Command {
 				)
 				fmt.Fprintf(
 					color.Output,
-					"Embedded Legacy CLI version %s\n",
-					color.CyanString(legacy.LegacyCLIVersion),
-				)
-				fmt.Fprintf(
-					color.Output,
 					"Commit %s (built %s by %s)\n",
 					color.CyanString(config.Commit),
 					color.CyanString(config.Date),

--- a/internal/legacy/legacy.go
+++ b/internal/legacy/legacy.go
@@ -23,10 +23,7 @@ import (
 //go:embed archives/platform.phar
 var phar []byte
 
-var (
-	LegacyCLIVersion = "0.0.0"
-	PHPVersion       = "0.0.0"
-)
+var PHPVersion = "0.0.0"
 
 const configBasename = "config.yaml"
 
@@ -58,7 +55,7 @@ func (c *CLIWrapper) cacheDir() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		cd = filepath.Join(cd, fmt.Sprintf("legacy-%s-%s", PHPVersion, LegacyCLIVersion))
+		cd = filepath.Join(cd, "legacy-"+c.Version)
 		if err := os.Mkdir(cd, 0o700); err != nil && !errors.Is(err, fs.ErrExist) {
 			return "", err
 		}
@@ -152,11 +149,10 @@ func (c *CLIWrapper) Exec(ctx context.Context, args ...string) error {
 		cmd.Env = append(cmd.Env, "CLICOLOR_FORCE=1")
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf(
-		"%sUSER_AGENT={APP_NAME_DASH}/%s ({UNAME_S}; {UNAME_R}; PHP %s; WRAPPER %s)",
+		"%sUSER_AGENT={APP_NAME_DASH}/%s ({UNAME_S}; {UNAME_R}; PHP %s)",
 		envPrefix,
-		LegacyCLIVersion,
-		PHPVersion,
 		c.Version,
+		PHPVersion,
 	))
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("could not run PHP CLI command: %w", err)

--- a/internal/legacy/legacy_test.go
+++ b/internal/legacy/legacy_test.go
@@ -53,7 +53,6 @@ func TestLegacyCLI(t *testing.T) {
 		wrapper.DebugLogFunc = t.Logf
 	}
 	PHPVersion = "6.5.4"
-	LegacyCLIVersion = "3.2.1"
 
 	err := wrapper.Exec(context.Background(), "help")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary

- Remove the `LegacyCLIVersion` variable (always reported "0.0.0" since 73a97c77)
- Remove "Embedded Legacy CLI version" from verbose `--version` output
- Simplify legacy cache directory from `legacy-{PHPVersion}-{LegacyCLIVersion}` to `legacy-{Version}`
- Simplify user agent string to use CLI version directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)