### PR TITLE
ci: add installer.sh test automation

### DIFF
--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -2,6 +2,11 @@ name: Test installer.sh
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'CLI version to install (leave empty for latest release)'
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -59,6 +64,7 @@ jobs:
         env:
           INSTALL_METHOD: ${{ matrix.method }}
           GITHUB_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
         run: sh installer.sh
 
       - name: Verify installation
@@ -82,6 +88,7 @@ jobs:
         env:
           INSTALL_METHOD: ${{ matrix.method }}
           GITHUB_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
         run: sh installer.sh
 
       - name: Verify installation

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -1,0 +1,88 @@
+name: Test installer.sh
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - installer.sh
+  pull_request:
+    paths:
+      - installer.sh
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: debian:bookworm
+            method: apt
+          - image: ubuntu:24.04
+            method: apt
+          - image: fedora:41
+            method: yum
+          - image: alpine:3.21
+            method: apk
+          - image: debian:bookworm
+            method: raw
+
+    steps:
+      - name: Install prerequisites
+        run: |
+          case "${{ matrix.method }}" in
+            apt)
+              apt-get update && apt-get install -y curl ca-certificates
+              ;;
+            yum)
+              yum install -y curl
+              ;;
+            apk)
+              apk add --no-cache curl ca-certificates
+              ;;
+            raw)
+              apt-get update && apt-get install -y curl ca-certificates gzip
+              ;;
+          esac
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run installer
+        env:
+          INSTALL_METHOD: ${{ matrix.method }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: sh installer.sh
+
+      - name: Verify installation
+        run: upsun --version
+
+  macos:
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        method:
+          - homebrew
+          - raw
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run installer
+        env:
+          INSTALL_METHOD: ${{ matrix.method }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: sh installer.sh
+
+      - name: Verify installation
+        run: upsun --version

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'CLI version to install (leave empty for latest release)'
+        description: 'CLI version to install for raw tests (leave empty for latest release)'
         required: false
         type: string
   push:
@@ -12,14 +12,19 @@ on:
       - main
     paths:
       - installer.sh
+      - .github/workflows/test-installer.yml
   pull_request:
     paths:
       - installer.sh
+      - .github/workflows/test-installer.yml
 
 permissions:
   contents: read
 
 jobs:
+  # Default install flow: the installer auto-detects the package manager.
+  # CI is overridden to empty so that is_ci() returns false (otherwise
+  # the installer would always select the "raw" method on Linux).
   linux:
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
@@ -31,66 +36,80 @@ jobs:
       matrix:
         include:
           - image: debian:bookworm
-            method: apt
+            prereqs: apt-get update && apt-get install -y curl ca-certificates
           - image: ubuntu:24.04
-            method: apt
+            prereqs: apt-get update && apt-get install -y curl ca-certificates
           - image: fedora:41
-            method: yum
+            prereqs: yum install -y curl
           - image: alpine:3.21
-            method: apk
-          - image: debian:bookworm
-            method: raw
+            prereqs: apk add --no-cache curl ca-certificates
 
     steps:
       - name: Install prerequisites
-        run: |
-          case "${{ matrix.method }}" in
-            apt)
-              apt-get update && apt-get install -y curl ca-certificates
-              ;;
-            yum)
-              yum install -y curl
-              ;;
-            apk)
-              apk add --no-cache curl ca-certificates
-              ;;
-            raw)
-              apt-get update && apt-get install -y curl ca-certificates gzip
-              ;;
-          esac
+        run: ${{ matrix.prereqs }}
 
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Run installer
         env:
-          INSTALL_METHOD: ${{ matrix.method }}
-          GITHUB_TOKEN: ${{ matrix.method == 'raw' && github.token || '' }}
-          VERSION: ${{ inputs.version }}
+          CI: ""
         run: sh installer.sh
 
       - name: Verify installation
         run: upsun --version
 
+  # Raw install on Linux: setting VERSION triggers the raw method.
+  # Without a VERSION input the installer queries the GitHub API for the
+  # latest release.
+  linux-raw:
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+    defaults:
+      run:
+        shell: sh
+    steps:
+      - name: Install prerequisites
+        run: apt-get update && apt-get install -y curl ca-certificates gzip
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run installer
+        env:
+          VERSION: ${{ inputs.version }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: sh installer.sh
+
+      - name: Verify installation
+        run: upsun --version
+
+  # Default install flow on macOS (auto-detects homebrew).
   macos:
     runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-    strategy:
-      fail-fast: false
-      matrix:
-        method:
-          - homebrew
-          - raw
+      - name: Run installer
+        run: sh installer.sh
 
+      - name: Verify installation
+        run: upsun --version
+
+  # Raw install on macOS (INSTALL_METHOD is required because VERSION
+  # does not affect macOS method selection).
+  macos-raw:
+    runs-on: macos-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Run installer
         env:
-          INSTALL_METHOD: ${{ matrix.method }}
-          GITHUB_TOKEN: ${{ matrix.method == 'raw' && github.token || '' }}
+          INSTALL_METHOD: raw
           VERSION: ${{ inputs.version }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: sh installer.sh
 
       - name: Verify installation

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -23,7 +23,9 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
-
+    defaults:
+      run:
+        shell: sh
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +65,7 @@ jobs:
       - name: Run installer
         env:
           INSTALL_METHOD: ${{ matrix.method }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ matrix.method == 'raw' && github.token || '' }}
           VERSION: ${{ inputs.version }}
         run: sh installer.sh
 
@@ -87,7 +89,7 @@ jobs:
       - name: Run installer
         env:
           INSTALL_METHOD: ${{ matrix.method }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ matrix.method == 'raw' && github.token || '' }}
           VERSION: ${{ inputs.version }}
         run: sh installer.sh
 

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -49,7 +49,7 @@ jobs:
         run: ${{ matrix.prereqs }}
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run installer
         env:
@@ -73,7 +73,7 @@ jobs:
         run: apt-get update && apt-get install -y curl ca-certificates gzip
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run installer
         env:
@@ -89,7 +89,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run installer
         run: sh installer.sh
@@ -103,7 +103,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run installer
         env:

--- a/scripts/test/installer.sh
+++ b/scripts/test/installer.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Test installer.sh across Linux distros using Docker.
+# Requires Docker to be installed and running.
+
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+pass=0
+fail=0
+errors=""
+
+run_test() {
+    image="$1"
+    method="$2"
+    prereqs="$3"
+
+    label="${image} (${method})"
+    printf "Testing %-35s " "$label"
+
+    if docker run --rm \
+        -v "$(pwd)/installer.sh:/installer.sh:ro" \
+        -e INSTALL_METHOD="$method" \
+        "$image" \
+        sh -c "${prereqs} sh /installer.sh && upsun --version" \
+        >/dev/null 2>&1; then
+        printf "PASS\n"
+        pass=$((pass + 1))
+    else
+        printf "FAIL\n"
+        fail=$((fail + 1))
+        errors="${errors}  ${label}\n"
+    fi
+}
+
+echo "installer.sh test suite"
+echo "======================="
+echo ""
+
+run_test "debian:bookworm" "apt" \
+    "apt-get update && apt-get install -y curl ca-certificates && "
+
+run_test "ubuntu:24.04" "apt" \
+    "apt-get update && apt-get install -y curl ca-certificates && "
+
+run_test "fedora:41" "yum" \
+    "yum install -y curl && "
+
+run_test "alpine:3.21" "apk" \
+    "apk add --no-cache curl ca-certificates && "
+
+run_test "debian:bookworm" "raw" \
+    "apt-get update && apt-get install -y curl ca-certificates gzip && "
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+
+if [ "$fail" -gt 0 ]; then
+    printf "\nFailed:\n%b" "$errors"
+    exit 1
+fi

--- a/scripts/test/installer.sh
+++ b/scripts/test/installer.sh
@@ -7,6 +7,8 @@ set -eu
 
 cd "$(dirname "$0")/../.."
 
+: "${VERSION:=}"
+
 pass=0
 fail=0
 errors=""
@@ -20,9 +22,15 @@ run_test() {
     echo ""
     echo "=== ${label} ==="
 
+    version_flag=""
+    if [ -n "$VERSION" ]; then
+        version_flag="-e VERSION=$VERSION"
+    fi
+
     if docker run --rm \
         -v "$(pwd)/installer.sh:/installer.sh:ro" \
         -e INSTALL_METHOD="$method" \
+        $version_flag \
         "$image" \
         sh -c "${prereqs}sh /installer.sh && upsun --version"; then
         echo "--- PASS: ${label} ---"

--- a/scripts/test/installer.sh
+++ b/scripts/test/installer.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Test installer.sh across Linux distros using Docker.
 # Requires Docker to be installed and running.
+# macOS methods (homebrew, raw) are only tested in CI (GitHub Actions).
 
 set -eu
 
@@ -16,18 +17,18 @@ run_test() {
     prereqs="$3"
 
     label="${image} (${method})"
-    printf "Testing %-35s " "$label"
+    echo ""
+    echo "=== ${label} ==="
 
     if docker run --rm \
         -v "$(pwd)/installer.sh:/installer.sh:ro" \
         -e INSTALL_METHOD="$method" \
         "$image" \
-        sh -c "${prereqs} sh /installer.sh && upsun --version" \
-        >/dev/null 2>&1; then
-        printf "PASS\n"
+        sh -c "${prereqs}sh /installer.sh && upsun --version"; then
+        echo "--- PASS: ${label} ---"
         pass=$((pass + 1))
     else
-        printf "FAIL\n"
+        echo "--- FAIL: ${label} ---"
         fail=$((fail + 1))
         errors="${errors}  ${label}\n"
     fi
@@ -35,24 +36,24 @@ run_test() {
 
 echo "installer.sh test suite"
 echo "======================="
-echo ""
 
 run_test "debian:bookworm" "apt" \
-    "apt-get update && apt-get install -y curl ca-certificates && "
+    "apt-get update -qq && apt-get install -y -qq curl ca-certificates && "
 
 run_test "ubuntu:24.04" "apt" \
-    "apt-get update && apt-get install -y curl ca-certificates && "
+    "apt-get update -qq && apt-get install -y -qq curl ca-certificates && "
 
 run_test "fedora:41" "yum" \
-    "yum install -y curl && "
+    "yum install -y -q curl && "
 
 run_test "alpine:3.21" "apk" \
-    "apk add --no-cache curl ca-certificates && "
+    "apk add -q --no-cache curl ca-certificates && "
 
 run_test "debian:bookworm" "raw" \
-    "apt-get update && apt-get install -y curl ca-certificates gzip && "
+    "apt-get update -qq && apt-get install -y -qq curl ca-certificates gzip && "
 
 echo ""
+echo "======================="
 echo "Results: ${pass} passed, ${fail} failed"
 
 if [ "$fail" -gt 0 ]; then

--- a/scripts/test/installer.sh
+++ b/scripts/test/installer.sh
@@ -22,15 +22,10 @@ run_test() {
     echo ""
     echo "=== ${label} ==="
 
-    version_flag=""
-    if [ -n "$VERSION" ]; then
-        version_flag="-e VERSION=$VERSION"
-    fi
-
     if docker run --rm \
         -v "$(pwd)/installer.sh:/installer.sh:ro" \
         -e INSTALL_METHOD="$method" \
-        $version_flag \
+        -e "VERSION=${VERSION}" \
         "$image" \
         sh -c "${prereqs}sh /installer.sh && upsun --version"; then
         echo "--- PASS: ${label} ---"

--- a/scripts/test/installer.sh
+++ b/scripts/test/installer.sh
@@ -13,19 +13,20 @@ pass=0
 fail=0
 errors=""
 
+# Run a test in a Docker container.
+# Arguments: label, image, prereqs, [extra docker args...]
 run_test() {
-    image="$1"
-    method="$2"
+    label="$1"
+    image="$2"
     prereqs="$3"
+    shift 3
 
-    label="${image} (${method})"
     echo ""
     echo "=== ${label} ==="
 
     if docker run --rm \
         -v "$(pwd)/installer.sh:/installer.sh:ro" \
-        -e INSTALL_METHOD="$method" \
-        -e "VERSION=${VERSION}" \
+        "$@" \
         "$image" \
         sh -c "${prereqs}sh /installer.sh && upsun --version"; then
         echo "--- PASS: ${label} ---"
@@ -40,20 +41,29 @@ run_test() {
 echo "installer.sh test suite"
 echo "======================="
 
-run_test "debian:bookworm" "apt" \
+# Default flow tests: let the installer auto-detect the install method.
+
+run_test "debian:bookworm (default)" "debian:bookworm" \
     "apt-get update -qq && apt-get install -y -qq curl ca-certificates && "
 
-run_test "ubuntu:24.04" "apt" \
+run_test "ubuntu:24.04 (default)" "ubuntu:24.04" \
     "apt-get update -qq && apt-get install -y -qq curl ca-certificates && "
 
-run_test "fedora:41" "yum" \
+run_test "fedora:41 (default)" "fedora:41" \
     "yum install -y -q curl && "
 
-run_test "alpine:3.21" "apk" \
+run_test "alpine:3.21 (default)" "alpine:3.21" \
     "apk add -q --no-cache curl ca-certificates && "
 
-run_test "debian:bookworm" "raw" \
-    "apt-get update -qq && apt-get install -y -qq curl ca-certificates gzip && "
+# Raw install test: setting VERSION triggers the raw method on Linux.
+if [ -n "$VERSION" ]; then
+    run_test "debian:bookworm (raw, VERSION=$VERSION)" "debian:bookworm" \
+        "apt-get update -qq && apt-get install -y -qq curl ca-certificates gzip && " \
+        -e "VERSION=${VERSION}"
+else
+    echo ""
+    echo "Skipping raw install test (set VERSION to enable)"
+fi
 
 echo ""
 echo "======================="


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow to test `installer.sh` on each supported OS/distro
- Default flow tests (no `INSTALL_METHOD`): the installer auto-detects the package manager (apt on Debian/Ubuntu, yum on Fedora, apk on Alpine, homebrew on macOS)
- Raw download tests: `VERSION` triggers the raw method on Linux; `INSTALL_METHOD=raw` for macOS
- `CI` is overridden to empty in the default flow jobs so the installer doesn't auto-select `raw` in GitHub Actions
- `workflow_dispatch` accepts a `VERSION` input for testing prereleases
- Add a local Docker-based test script (`scripts/test/installer.sh`) for quick iteration

Generated with [Claude Code](https://claude.com/claude-code)