### PR TITLE
fix(ci): prevent dirty git state in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,10 +115,6 @@ jobs:
       - name: Install Go tools
         run: make goreleaser repogen
 
-      - name: Override tap skip_upload
-        if: inputs.upload_taps == true
-        run: "sed -i 's/skip_upload: auto/skip_upload: false/' .goreleaser.yaml"
-
       - name: Build release (tag)
         if: startsWith(github.ref, 'refs/tags/') || inputs.tag
         env:
@@ -127,6 +123,7 @@ jobs:
           RSA_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/rsa-signing-key.pem
           GPG_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/gpg-signing-key.asc
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          SKIP_UPLOAD_TAPS: ${{ inputs.upload_taps == true && 'false' || 'auto' }}
         run: make release
 
       - name: Build snapshot (branch)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -155,7 +155,7 @@ archives:
 
 brews:
   - name: platformsh-cli
-    skip_upload: auto
+    skip_upload: '{{ envOrDefault "SKIP_UPLOAD_TAPS" "auto" }}'
     repository:
       owner: upsun
       name: homebrew-tap
@@ -186,7 +186,7 @@ brews:
       system "#{bin}/platform --version"
 
   - name: upsun-cli
-    skip_upload: auto
+    skip_upload: '{{ envOrDefault "SKIP_UPLOAD_TAPS" "auto" }}'
     repository:
       owner: upsun
       name: homebrew-tap
@@ -218,7 +218,7 @@ brews:
 
 scoops:
   - name: platform
-    skip_upload: auto
+    skip_upload: '{{ envOrDefault "SKIP_UPLOAD_TAPS" "auto" }}'
     repository:
       owner: upsun
       name: homebrew-tap
@@ -240,7 +240,7 @@ scoops:
       - extras/vcredist2022
 
   - name: upsun
-    skip_upload: auto
+    skip_upload: '{{ envOrDefault "SKIP_UPLOAD_TAPS" "auto" }}'
     repository:
       owner: upsun
       name: homebrew-tap


### PR DESCRIPTION
## Summary

Fixes the "git is in a dirty state" error that occurs when running the release workflow with `upload_repos` enabled.

The workflow was using `sed` to modify `.goreleaser.yaml` in-place when the `upload_taps` checkbox was enabled, causing GoReleaser to detect modified files and fail validation.

**Solution**: Replace file modification with environment variable approach:
- Use GoReleaser's `envOrDefault` template function to read `SKIP_UPLOAD_TAPS` from environment
- Set the environment variable in the workflow based on the `upload_taps` input
- Preserves identical GitHub UI behavior (same checkbox, same functionality)

## Test plan

- [ ] Verify workflow runs successfully without `upload_taps` checkbox (should use `auto`)
- [ ] Verify workflow runs successfully with `upload_taps` checkbox enabled (should use `false`)
- [ ] Confirm no "dirty git state" error appears in GoReleaser output
- [ ] Validate that Homebrew/Scoop uploads work as expected when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)