### PR TITLE
fix(ci): allow asset replacement on manual workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,7 @@ jobs:
           GPG_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/gpg-signing-key.asc
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           SKIP_UPLOAD_TAPS: ${{ inputs.upload_taps == true && 'false' || 'auto' }}
+          RELEASE_MODE: ${{ github.event_name == 'workflow_dispatch' && 'replace' || 'append' }}
         run: make release
 
       - name: Build snapshot (branch)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,6 +101,7 @@ universal_binaries:
     replace: true
 
 release:
+  mode: '{{ envOrDefault "RELEASE_MODE" "append" }}'
   github:
     owner: upsun
     name: cli


### PR DESCRIPTION
## Summary
- Sets release mode to `replace` when workflow is manually triggered via workflow_dispatch
- Keeps default `append` mode for automatic releases

## Why
Allows re-running failed releases or fixing release assets by manually triggering the workflow without encountering "asset already exists" errors.

## Test plan
- [ ] Verify automatic releases still use append mode
- [ ] Verify manual workflow_dispatch uses replace mode
- [ ] Test manual re-trigger of release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)