### PR TITLE
fix(ci): allow re-running releases without artifact conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           GPG_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/gpg-signing-key.asc
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           SKIP_UPLOAD_TAPS: ${{ inputs.upload_taps == true && 'false' || 'auto' }}
-          RELEASE_MODE: ${{ github.event_name == 'workflow_dispatch' && 'replace' || 'append' }}
+          REPLACE_EXISTING_ARTIFACTS: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
         run: make release
 
       - name: Build snapshot (branch)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,6 @@ jobs:
           GPG_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/gpg-signing-key.asc
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           SKIP_UPLOAD_TAPS: ${{ inputs.upload_taps == true && 'false' || 'auto' }}
-          REPLACE_EXISTING_ARTIFACTS: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
         run: make release
 
       - name: Build snapshot (branch)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,7 +101,7 @@ universal_binaries:
     replace: true
 
 release:
-  mode: '{{ envOrDefault "RELEASE_MODE" "append" }}'
+  replace_existing_artifacts: {{ if eq .Env.REPLACE_EXISTING_ARTIFACTS "true" }}true{{ else }}false{{ end }}
   github:
     owner: upsun
     name: cli

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,7 +101,7 @@ universal_binaries:
     replace: true
 
 release:
-  replace_existing_artifacts: {{ envOrDefault "REPLACE_EXISTING_ARTIFACTS" "false" }}
+  replace_existing_artifacts: true
   github:
     owner: upsun
     name: cli

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,7 +101,7 @@ universal_binaries:
     replace: true
 
 release:
-  replace_existing_artifacts: {{ if eq .Env.REPLACE_EXISTING_ARTIFACTS "true" }}true{{ else }}false{{ end }}
+  replace_existing_artifacts: {{ envOrDefault "REPLACE_EXISTING_ARTIFACTS" "false" }}
   github:
     owner: upsun
     name: cli


### PR DESCRIPTION
## Summary
- Replace `mode` property with `replace_existing_artifacts` in GoReleaser config

## Test plan
- [ ] Verify GoReleaser config validates
- [ ] Test manual workflow_dispatch trigger replaces artifacts
- [ ] Test tag push (non-workflow_dispatch) appends artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)