### PR TITLE
fix(ci): use GitHub App token for homebrew-tap push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,20 @@ jobs:
       - name: Install Go tools
         run: make goreleaser repogen
 
+      - name: Generate GitHub App token for homebrew-tap
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: homebrew-tap
+
       - name: Build release (tag)
         if: startsWith(github.ref, 'refs/tags/') || inputs.tag
         env:
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RSA_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/rsa-signing-key.pem
           GPG_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/gpg-signing-key.asc
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
 
       - name: Generate GitHub App token for homebrew-tap
         id: app-token
+        if: startsWith(github.ref, 'refs/tags/') || inputs.tag
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.APP_ID }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -160,7 +160,7 @@ brews:
     repository:
       owner: upsun
       name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     ids:
       - platform
 
@@ -191,7 +191,7 @@ brews:
     repository:
       owner: upsun
       name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     ids:
       - upsun
 
@@ -223,7 +223,7 @@ scoops:
     repository:
       owner: upsun
       name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     ids:
       - platform
 
@@ -245,7 +245,7 @@ scoops:
     repository:
       owner: upsun
       name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     ids:
       - upsun
 


### PR DESCRIPTION
## Summary
- Generates a scoped GitHub App token for `upsun/homebrew-tap` using `actions/create-github-app-token@v2`
- Replaces `GITHUB_TOKEN` with `TAP_GITHUB_TOKEN` in all GoReleaser brew/scoop repository configs
- Token generation is gated behind the same `if:` condition as the release step, so it's only minted during actual releases

## Test Plan
- [ ] Trigger a manual release via `workflow_dispatch` with a tag and verify the token step runs and taps are updated
- [ ] Trigger a snapshot build and verify the token step is skipped