### PR TITLE
fix(init): ignore unknown data keys in AI config stream

### DIFF
--- a/internal/init/command.go
+++ b/internal/init/command.go
@@ -141,7 +141,7 @@ func RunAIConfig(
 			if key == "output" {
 				return json.Unmarshal(data, &apiOutput)
 			}
-			return fmt.Errorf("unexpected data key: %s", key)
+			return nil
 		})
 		eg, egCtx = errgroup.WithContext(ctx)
 		msgChan   = make(chan streaming.Message, 10) // Buffered to prevent deadlock if handleMessage errors.


### PR DESCRIPTION
## Summary

- The NDJSON stream handler in `upsun init` errored on unrecognized data keys, which broke the CLI when the API added a new `topology` key
- Ignore unknown keys so future API additions don't break older CLI versions

Generated with [Claude Code](https://claude.ai/code)