### PR TITLE
Use API base URL for AI configuration endpoint

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -109,9 +108,6 @@ func runInitCommand(
 
 	cnf := config.FromContext(cmd.Context())
 
-	// TODO check if this is needed
-	cnf.API.AIServiceURL = cmp.Or(os.Getenv(cnf.Application.EnvPrefix+"API_AI_URL"), cnf.API.AIServiceURL)
-
 	legacyCLIClient, err := auth.NewLegacyCLIClient(cmd.Context(),
 		makeLegacyCLIWrapper(cnf, cmd.OutOrStdout(), cmd.ErrOrStderr(), cmd.InOrStdin()))
 	if err != nil {
@@ -183,7 +179,7 @@ func runInitCommand(
 	}
 
 	initOptions.HTTPClient = legacyCLIClient.HTTPClient
-	initOptions.AIServiceURL = cnf.API.AIServiceURL
+	initOptions.APIURL = cnf.API.BaseURL
 	initOptions.UserAgent = cnf.UserAgent()
 	initOptions.IsInteractive = isInteractive
 	initOptions.Yes = viper.GetBool("yes")
@@ -232,9 +228,6 @@ func handleOrganizations(
 func canUseAI(cnf *config.Config) (msg string, canUseAI bool) {
 	if !cnf.API.EnableOrganizations {
 		return "using AI requires Organizations to be enabled", false
-	}
-	if cnf.API.AIServiceURL == "" {
-		return "using AI requires the service URL to be set", false
 	}
 	return "", true
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -48,14 +48,12 @@ type Config struct {
 		UserAgent string `validate:"omitempty" yaml:"user_agent,omitempty"`       // a template - see UserAgent method
 		SessionID string `validate:"omitempty,ascii" yaml:"session_id,omitempty"` // the ID for the authentication session - defaults to "default"
 
-		OAuth2ClientID     string `validate:"omitempty" yaml:"oauth2_client_id,omitempty"`                               // e.g. "upsun-cli"
-		OAuth2AuthorizeURL string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_auth_url,omitempty"`   // e.g. "https://auth.upsun.com/oauth2/authorize"
-		OAuth2RevokeURL    string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_revoke_url,omitempty"` // e.g. "https://auth.upsun.com/oauth2/revoke"
-		OAuth2TokenURL     string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_token_url,omitempty"`  // e.g. "https://auth.upsun.com/oauth2/token"
-		CertifierURL       string `validate:"required_without=AuthURL,omitempty,url" yaml:"certifier_url,omitempty"`     // No longer used
-
-		AIServiceURL        string `validate:"omitempty,url" yaml:"ai_url,omitempty"`    // The AI service URL, e.g. "https://ai.upsun.com".
-		EnableOrganizations bool   `validate:"omitempty" yaml:"organizations,omitempty"` // Whether the "organizations" feature is enabled.
+		OAuth2ClientID      string `validate:"omitempty" yaml:"oauth2_client_id,omitempty"`                               // e.g. "upsun-cli"
+		OAuth2AuthorizeURL  string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_auth_url,omitempty"`   // e.g. "https://auth.upsun.com/oauth2/authorize"
+		OAuth2RevokeURL     string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_revoke_url,omitempty"` // e.g. "https://auth.upsun.com/oauth2/revoke"
+		OAuth2TokenURL      string `validate:"required_without=AuthURL,omitempty,url" yaml:"oauth2_token_url,omitempty"`  // e.g. "https://auth.upsun.com/oauth2/token"
+		CertifierURL        string `validate:"required_without=AuthURL,omitempty,url" yaml:"certifier_url,omitempty"`     // No longer used
+		EnableOrganizations bool   `validate:"omitempty" yaml:"organizations,omitempty"`                                  // Whether the "organizations" feature is enabled.
 	} `validate:"required"`
 	Detection struct {
 		GitRemoteName string   `validate:"required" yaml:"git_remote_name"` // e.g. "upsun"

--- a/internal/config/upsun-cli.yaml
+++ b/internal/config/upsun-cli.yaml
@@ -54,8 +54,6 @@ api:
   auth_url: "https://auth.upsun.com"
   oauth2_client_id: "upsun-cli"
 
-  ai_url: "https://ai.upsun.com"
-
   organization_types: [flexible, fixed]
   default_organization_type: flexible
 

--- a/internal/init/command.go
+++ b/internal/init/command.go
@@ -31,7 +31,7 @@ type Options struct {
 	ExtraContext   string
 
 	HTTPClient     *http.Client
-	AIServiceURL   string
+	APIURL         string
 	UserAgent      string
 	RequestTimeout time.Duration // Defaults to 10 minutes
 
@@ -53,8 +53,8 @@ func RunAIConfig(
 	opts *Options,
 	stdout, stderr io.Writer,
 ) error {
-	if opts.AIServiceURL == "" {
-		return fmt.Errorf("no AI service URL available")
+	if opts.APIURL == "" {
+		return fmt.Errorf("no API URL available")
 	}
 	if opts.HTTPClient == nil {
 		opts.HTTPClient = http.DefaultClient
@@ -88,7 +88,7 @@ func RunAIConfig(
 		return err
 	}
 
-	u, err := url.Parse(opts.AIServiceURL)
+	u, err := url.Parse(opts.APIURL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Remove the separate `ai_url` config field (`ai.upsun.com`) and use the existing API base URL (`api.upsun.com`) for the `/ai/generate-configuration` endpoint
- Remove the `UPSUN_CLI_API_AI_URL` environment variable override
- Rename `AIServiceURL` to `APIURL` in init options

Generated with [Claude Code](https://claude.ai/code)