### PR TITLE
feat(docker): add Docker image build and publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -120,3 +121,65 @@ jobs:
         if: always()
         run: |
           rm -rf "${{ steps.signing-keys.outputs.key_dir }}"
+
+  docker:
+    runs-on: ${{ matrix.runner }}
+    needs: release
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            suffix: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            suffix: arm64
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: https://github.com/${{ github.repository }}.git#${{ github.ref }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ghcr.io/upsun/cli:${{ github.ref_name }}-${{ matrix.suffix }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          cache-from: type=gha,scope=${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.suffix }}
+
+  docker-manifest:
+    runs-on: ubuntu-latest
+    needs: docker
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          docker manifest create ghcr.io/upsun/cli:${{ github.ref_name }} \
+            ghcr.io/upsun/cli:${{ github.ref_name }}-amd64 \
+            ghcr.io/upsun/cli:${{ github.ref_name }}-arm64
+          docker manifest push ghcr.io/upsun/cli:${{ github.ref_name }}
+          docker manifest create ghcr.io/upsun/cli:latest \
+            ghcr.io/upsun/cli:${{ github.ref_name }}-amd64 \
+            ghcr.io/upsun/cli:${{ github.ref_name }}-arm64
+          docker manifest push ghcr.io/upsun/cli:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ on:
 permissions:
   contents: write
 
+env:
+  IMAGE: ghcr.io/upsun/cli
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -201,7 +204,7 @@ jobs:
           context: https://github.com/${{ github.repository }}.git#${{ needs.release.outputs.tag }}
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-${{ matrix.suffix }}
+          tags: ${{ env.IMAGE }}:${{ needs.release.outputs.tag }}-${{ matrix.suffix }}
           build-args: |
             VERSION=${{ needs.release.outputs.tag }}
           cache-from: type=gha,scope=${{ matrix.suffix }}
@@ -224,14 +227,14 @@ jobs:
       - name: Create and push versioned manifest
         run: |
           docker buildx imagetools create \
-            --tag ghcr.io/upsun/cli:${{ needs.release.outputs.tag }} \
-            ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-amd64 \
-            ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-arm64
+            --tag ${{ env.IMAGE }}:${{ needs.release.outputs.tag }} \
+            ${{ env.IMAGE }}:${{ needs.release.outputs.tag }}-amd64 \
+            ${{ env.IMAGE }}:${{ needs.release.outputs.tag }}-arm64
 
       - name: Create and push latest manifest
         if: needs.release.outputs.is_prerelease == 'false'
         run: |
           docker buildx imagetools create \
-            --tag ghcr.io/upsun/cli:latest \
-            ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-amd64 \
-            ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-arm64
+            --tag ${{ env.IMAGE }}:latest \
+            ${{ env.IMAGE }}:${{ needs.release.outputs.tag }}-amd64 \
+            ${{ env.IMAGE }}:${{ needs.release.outputs.tag }}-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,16 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      is_prerelease: ${{ steps.tag.outputs.is_prerelease }}
 
     steps:
       - name: Resolve tag
@@ -194,19 +198,20 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: https://github.com/${{ github.repository }}.git#${{ github.ref }}
+          context: https://github.com/${{ github.repository }}.git#${{ needs.release.outputs.tag }}
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ghcr.io/upsun/cli:${{ github.ref_name }}-${{ matrix.suffix }}
+          tags: ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-${{ matrix.suffix }}
           build-args: |
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ needs.release.outputs.tag }}
           cache-from: type=gha,scope=${{ matrix.suffix }}
           cache-to: type=gha,mode=max,scope=${{ matrix.suffix }}
 
   docker-manifest:
     runs-on: ubuntu-latest
-    needs: docker
+    needs: [docker, release]
     permissions:
+      contents: read
       packages: write
     steps:
       - name: Log in to GHCR
@@ -216,13 +221,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push manifest
+      - name: Create and push versioned manifest
         run: |
-          docker manifest create ghcr.io/upsun/cli:${{ github.ref_name }} \
-            ghcr.io/upsun/cli:${{ github.ref_name }}-amd64 \
-            ghcr.io/upsun/cli:${{ github.ref_name }}-arm64
-          docker manifest push ghcr.io/upsun/cli:${{ github.ref_name }}
-          docker manifest create ghcr.io/upsun/cli:latest \
-            ghcr.io/upsun/cli:${{ github.ref_name }}-amd64 \
-            ghcr.io/upsun/cli:${{ github.ref_name }}-arm64
-          docker manifest push ghcr.io/upsun/cli:latest
+          docker buildx imagetools create \
+            --tag ghcr.io/upsun/cli:${{ needs.release.outputs.tag }} \
+            ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-amd64 \
+            ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-arm64
+
+      - name: Create and push latest manifest
+        if: needs.release.outputs.is_prerelease == 'false'
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/upsun/cli:latest \
+            ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-amd64 \
+            ghcr.io/upsun/cli:${{ needs.release.outputs.tag }}-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 
 # Install dependencies
 RUN apt-get update && \
-    apt-get install -y curl bash git ssh-client && \
+    apt-get install -y --no-install-recommends curl bash git ssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Upsun CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:24.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y curl bash git ssh-client && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Upsun CLI
+ARG VERSION=
+RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/main/installer.sh | INSTALL_METHOD=raw VERSION=$VERSION bash
+
+# Default command
+ENTRYPOINT ["upsun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 # Install Upsun CLI
 ARG VERSION=
-RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/main/installer.sh | INSTALL_METHOD=raw VERSION=$VERSION bash
+RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/$VERSION/installer.sh | INSTALL_METHOD=raw VERSION=$VERSION bash
 
 # Default command
 ENTRYPOINT ["upsun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM ubuntu:24.04
+FROM alpine:3
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl git openssh-client && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates curl git openssh-client
 
 ARG VERSION=
-RUN [ -n "$VERSION" ] || { echo "ERROR: VERSION build arg must be set" >&2; exit 1; }
+RUN [ -n "$VERSION" ] || { echo "VERSION is required" >&2; exit 1; }
 COPY installer.sh /tmp/installer.sh
-RUN INSTALL_METHOD=raw VERSION=$VERSION sh /tmp/installer.sh && \
-    rm /tmp/installer.sh
+RUN INSTALL_METHOD=raw VERSION=$VERSION sh /tmp/installer.sh && rm /tmp/installer.sh
 
 ENTRYPOINT ["upsun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ARG VERSION=
+RUN [ -n "$VERSION" ] || { echo "ERROR: VERSION build arg must be set" >&2; exit 1; }
 RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/$VERSION/installer.sh -o /tmp/installer.sh && \
     INSTALL_METHOD=raw VERSION=$VERSION sh /tmp/installer.sh && \
     rm /tmp/installer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:24.04
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl bash git ssh-client && \
+    apt-get install -y --no-install-recommends ca-certificates curl git openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 ARG VERSION=
 RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/$VERSION/installer.sh -o /tmp/installer.sh && \
-    INSTALL_METHOD=raw VERSION=$VERSION bash /tmp/installer.sh && \
+    INSTALL_METHOD=raw VERSION=$VERSION sh /tmp/installer.sh && \
     rm /tmp/installer.sh
 
 ENTRYPOINT ["upsun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update && \
 
 ARG VERSION=
 RUN [ -n "$VERSION" ] || { echo "ERROR: VERSION build arg must be set" >&2; exit 1; }
-RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/$VERSION/installer.sh -o /tmp/installer.sh && \
-    INSTALL_METHOD=raw VERSION=$VERSION sh /tmp/installer.sh && \
+COPY installer.sh /tmp/installer.sh
+RUN INSTALL_METHOD=raw VERSION=$VERSION sh /tmp/installer.sh && \
     rm /tmp/installer.sh
 
 ENTRYPOINT ["upsun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:24.04
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl bash git ssh-client && \
+    apt-get install -y --no-install-recommends ca-certificates curl bash git ssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 ARG VERSION=
-RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/$VERSION/installer.sh | INSTALL_METHOD=raw VERSION=$VERSION bash
+RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/$VERSION/installer.sh -o /tmp/installer.sh && \
+    INSTALL_METHOD=raw VERSION=$VERSION bash /tmp/installer.sh && \
+    rm /tmp/installer.sh
 
 ENTRYPOINT ["upsun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM ubuntu:24.04
 
-# Install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl bash git ssh-client && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Upsun CLI
 ARG VERSION=
 RUN curl -fsSL https://raw.githubusercontent.com/upsun/cli/$VERSION/installer.sh | INSTALL_METHOD=raw VERSION=$VERSION bash
 
-# Default command
 ENTRYPOINT ["upsun"]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ sudo dnf install -y upsun-cli
 
 For manual installation, you can also [download the latest binaries](https://github.com/upsun/cli/releases/latest).
 
+### Docker
+
+The CLI is also available as a Docker image:
+
+```console
+docker run --rm -it ghcr.io/upsun/cli
+```
+
+To use a specific version:
+
+```console
+docker run --rm -it ghcr.io/upsun/cli:6.0.0
+```
+
 ## Upgrade
 
 Upgrade using the same tool:
@@ -188,6 +202,7 @@ Releases are automated via GitHub Actions. To create a new release:
    - Sign packages (APK, DEB, RPM)
    - Create a GitHub release with all artifacts
    - Update package repositories at repositories.upsun.com
+   - Build and push Docker image to ghcr.io/upsun/cli
 
 ## Licenses
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ docker run --rm -it ghcr.io/upsun/cli
 To use a specific version:
 
 ```console
-docker run --rm -it ghcr.io/upsun/cli:6.0.0
+docker run --rm -it ghcr.io/upsun/cli:v6.0.0
 ```
 
 ## Upgrade

--- a/README.md
+++ b/README.md
@@ -120,12 +120,6 @@ The CLI is also available as a Docker image:
 docker run --rm -it ghcr.io/upsun/cli
 ```
 
-To use a specific version:
-
-```console
-docker run --rm -it ghcr.io/upsun/cli:v6.0.0
-```
-
 ## Upgrade
 
 Upgrade using the same tool:


### PR DESCRIPTION
## Summary

- Adds a `Dockerfile` that installs the Upsun CLI from a released version using the installer script
- Adds `docker` and `docker-manifest` jobs to the release workflow that build and push a multi-arch image (`linux/amd64` + `linux/arm64`) to `ghcr.io/upsun/cli` after each release
- Updates `README.md` with Docker installation instructions

## Test Plan
- [ ] Trigger a release and verify the `docker` and `docker-manifest` jobs complete successfully
- [ ] Pull `ghcr.io/upsun/cli:<tag>` on both amd64 and arm64 and confirm `upsun --version` returns the correct version
- [ ] Verify `ghcr.io/upsun/cli:latest` is updated only for non-prerelease tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)