### PR TITLE
installer: remove "formerly Platform.sh"

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -31,7 +31,7 @@ set -eu
 
 # global variables
 binary="upsun"
-vendor_name="Upsun (formerly Platform.sh)"
+vendor_name="Upsun"
 cmd_shasum=""
 cmd_sudo=""
 dir_bin="/usr/bin"


### PR DESCRIPTION
It's been a while, and this installer does not have vendor support anyway.

The [older installer](https://github.com/platformsh/cli/blob/main/installer.sh) can still mention the "formerly Platform.sh", for the sake of continuity: I think this change means less surprise for both existing users and new users.