### PR TITLE
Improve --latest option (legacy)

### DIFF
--- a/legacy/src/Command/Metrics/MetricsCommandBase.php
+++ b/legacy/src/Command/Metrics/MetricsCommandBase.php
@@ -40,7 +40,8 @@ abstract class MetricsCommandBase extends CommandBase
     public const MIN_INTERVAL = 60; // 1 minute
 
     public const MIN_RANGE = 300; // 5 minutes
-    public const DEFAULT_RANGE = 600;
+    public const DEFAULT_RANGE = 600; // 10 minutes
+    public const LATEST_GRAIN = 300; // 5 minutes
 
     /**
      * @var bool whether services have been identified that use high memory
@@ -97,7 +98,7 @@ abstract class MetricsCommandBase extends CommandBase
             . "\n" . \sprintf('Minimum <comment>%s</comment>.', $duration->humanize(self::MIN_INTERVAL)),
         );
         $this->addOption('to', null, InputOption::VALUE_REQUIRED, 'The end time. Defaults to now.');
-        $this->addOption('latest', '1', InputOption::VALUE_NONE, 'Show only the latest single data point');
+        $this->addOption('latest', '1', InputOption::VALUE_NONE, 'Show only the latest single data point' . "\n" . 'Defaults to a 5-minute aggregation window to ensure all containers are included. Override with <comment>--interval</comment>.');
         $this->addOption('service', 's', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter by service or application name' . "\n" . Wildcard::HELP);
         $this->addOption('type', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter by service type (if --service is not provided). The version is not required.' . "\n" . Wildcard::HELP);
 
@@ -264,6 +265,8 @@ abstract class MetricsCommandBase extends CommandBase
      */
     protected function validateTimeInput(InputInterface $input): false|TimeSpec
     {
+        $isLatest = $input->getOption('latest');
+
         if ($to = $input->getOption('to')) {
             $endTime = \strtotime((string) $to);
             if (!$endTime) {
@@ -286,6 +289,8 @@ abstract class MetricsCommandBase extends CommandBase
                 return false;
             }
             $rangeSeconds = (int) $rangeSeconds;
+        } elseif ($isLatest && !$input->getOption('interval')) {
+            $rangeSeconds = self::LATEST_GRAIN;
         } else {
             $rangeSeconds = self::DEFAULT_RANGE;
         }
@@ -307,6 +312,8 @@ abstract class MetricsCommandBase extends CommandBase
 
                 return false;
             }
+        } elseif ($isLatest) {
+            $interval = self::LATEST_GRAIN;
         }
 
         return new TimeSpec($startTime, $endTime, $interval);

--- a/legacy/src/Command/Metrics/MetricsCommandBase.php
+++ b/legacy/src/Command/Metrics/MetricsCommandBase.php
@@ -266,6 +266,8 @@ abstract class MetricsCommandBase extends CommandBase
     protected function validateTimeInput(InputInterface $input): false|TimeSpec
     {
         $isLatest = $input->getOption('latest');
+        $intervalString = $input->getOption('interval');
+        $intervalProvided = $intervalString !== null && $intervalString !== '';
 
         if ($to = $input->getOption('to')) {
             $endTime = \strtotime((string) $to);
@@ -289,7 +291,7 @@ abstract class MetricsCommandBase extends CommandBase
                 return false;
             }
             $rangeSeconds = (int) $rangeSeconds;
-        } elseif ($isLatest && !$input->getOption('interval')) {
+        } elseif ($isLatest && !$intervalProvided) {
             $rangeSeconds = self::LATEST_GRAIN;
         } else {
             $rangeSeconds = self::DEFAULT_RANGE;
@@ -298,11 +300,11 @@ abstract class MetricsCommandBase extends CommandBase
         $startTime = $endTime - $rangeSeconds;
         $interval = null;
 
-        if ($intervalString = $input->getOption('interval')) {
+        if ($intervalProvided) {
             $interval = (int) (new Duration())->toSeconds($intervalString);
 
             if (empty($interval)) {
-                $this->stdErr->writeln('Invalid --range: <error>' . $intervalString . '</error>');
+                $this->stdErr->writeln('Invalid --interval: <error>' . $intervalString . '</error>');
 
                 return false;
             }


### PR DESCRIPTION
Migrated from platformsh/legacy-cli#1596 (original author: @mharacewiat).

Adds a `LATEST_GRAIN` constant (300s) used as the default range and interval when `--latest` is given without an explicit `--interval`, and updates the option help to mention the 5-minute aggregation window. The 5.x DI/`public const` style was preserved when re-applying the patch.

Closes #45 