### PR TITLE
fix(legacy): clarify why certain functions are not available on fixed plans

### DIFF
--- a/legacy/src/Command/Resources/Build/BuildResourcesGetCommand.php
+++ b/legacy/src/Command/Resources/Build/BuildResourcesGetCommand.php
@@ -42,7 +42,12 @@ class BuildResourcesGetCommand extends CommandBase
     {
         $selection = $this->selector->getSelection($input);
         if (!$this->api->supportsSizingApi($selection->getProject())) {
-            $this->stdErr->writeln(sprintf('The flexible resources API is not enabled for the project %s.', $this->api->getProjectLabel($selection->getProject(), 'comment')));
+            $this->stdErr->writeln(sprintf(
+                'The flexible resources API is not enabled for the project %s.' . "\n"
+                . 'The function you attempted to use is not available on upsun fixed (platformsh).' . "\n"
+                . 'Please refer to the Upsun fixed (platformsh) documentation: https://fixed.docs.upsun.com/',
+                $this->api->getProjectLabel($selection->getProject(), 'comment')
+            ));
             return 1;
         }
 

--- a/legacy/src/Command/Resources/Build/BuildResourcesGetCommand.php
+++ b/legacy/src/Command/Resources/Build/BuildResourcesGetCommand.php
@@ -44,8 +44,8 @@ class BuildResourcesGetCommand extends CommandBase
         if (!$this->api->supportsSizingApi($selection->getProject())) {
             $this->stdErr->writeln(sprintf(
                 'The flexible resources API is not enabled for the project %s.' . "\n"
-                . 'The function you attempted to use is not available on upsun fixed (platformsh).' . "\n"
-                . 'Please refer to the Upsun fixed (platformsh) documentation: https://fixed.docs.upsun.com/',
+                . 'The function you attempted to use is not available on fixed plans.' . "\n"
+                . 'Please refer to the Fixed documentation: https://fixed.docs.upsun.com/',
                 $this->api->getProjectLabel($selection->getProject(), 'comment')
             ));
             return 1;


### PR DESCRIPTION
Migrated from platformsh/legacy-cli#1598 (original author: @matthiaz). Two upstream commits squashed in order on this branch: the initial fix and the wording follow-up.

Customer context (from the original PR): a user saw `The flexible resources API is not enabled for the project ...` on a fixed plan and tried to follow the suggestion to enable it. The new message clarifies that the function is not available on fixed plans and links to the Fixed docs.

Adapted to the 5.x architecture in `legacy/` (DI-based `$selection` and `$this->api`), and the original `\n` literals inside a single-quoted string were rewritten as concatenated `"\n"` so the newlines actually render. The URL `https://fixed.docs.upsun.com/` is preserved verbatim from the source PR — please verify it points at the right docs target before merging.