### PR TITLE
Add --app-scope option for variables (legacy)

### DIFF
--- a/integration-tests/variable_write_test.go
+++ b/integration-tests/variable_write_test.go
@@ -72,3 +72,102 @@ func TestVariableCreate(t *testing.T) {
 	assert.NoError(t, err)
 	assertTrimmed(t, "false", f.Run("var:get", "-p", projectID, "env:TEST", "-l", "p", "-P", "visible_runtime"))
 }
+
+func TestVariableCreateWithAppScope(t *testing.T) {
+	authServer := mockapi.NewAuthServer(t)
+	t.Cleanup(authServer.Close)
+
+	apiHandler := mockapi.NewHandler(t)
+	apiServer := httptest.NewServer(apiHandler)
+	t.Cleanup(apiServer.Close)
+
+	projectID := mockapi.ProjectID()
+
+	apiHandler.SetProjects([]*mockapi.Project{{
+		ID: projectID,
+		Links: mockapi.MakeHALLinks(
+			"self=/projects/"+projectID,
+			"environments=/projects/"+projectID+"/environments",
+		),
+		DefaultBranch: "main",
+	}})
+
+	main := makeEnv(projectID, "main", "production", "active", nil)
+	main.Links["#variables"] = mockapi.HALLink{HREF: "/projects/" + projectID + "/environments/main/variables"}
+	main.Links["#manage-variables"] = mockapi.HALLink{HREF: "/projects/" + projectID + "/environments/main/variables"}
+	main.SetCurrentDeployment(&mockapi.Deployment{
+		WebApps: map[string]mockapi.App{
+			"app1": {Name: "app1", Type: "golang:1.23"},
+			"app2": {Name: "app2", Type: "php:8.3"},
+		},
+		Routes: map[string]any{},
+		Links:  mockapi.MakeHALLinks("self=/projects/" + projectID + "/environments/main/deployment/current"),
+	})
+	apiHandler.SetEnvironments([]*mockapi.Environment{main})
+
+	f := newCommandFactory(t, apiServer.URL, authServer.URL)
+
+	_, stdErr, err := f.RunCombinedOutput("var:create", "-p", projectID, "-l", "p",
+		"env:SCOPED", "--value", "val", "--app-scope", "app1")
+	assert.NoError(t, err)
+	assert.Contains(t, stdErr, "Creating variable env:SCOPED")
+
+	out := f.Run("var:get", "-p", projectID, "-l", "p", "env:SCOPED", "-P", "application_scope")
+	assert.Contains(t, out, "app1")
+
+	_, _, err = f.RunCombinedOutput("var:create", "-p", projectID, "-l", "p",
+		"env:MULTI", "--value", "val", "--app-scope", "app1", "--app-scope", "app2")
+	assert.NoError(t, err)
+
+	out = f.Run("var:get", "-p", projectID, "-l", "p", "env:MULTI", "-P", "application_scope")
+	assert.Contains(t, out, "app1")
+	assert.Contains(t, out, "app2")
+
+	_, stdErr, err = f.RunCombinedOutput("var:create", "-p", projectID, "-l", "p",
+		"env:BAD", "--value", "val", "--app-scope", "nonexistent")
+	assert.Error(t, err)
+	assert.Contains(t, stdErr, "was not found")
+
+	_, _, err = f.RunCombinedOutput("var:update", "-p", projectID, "-l", "p",
+		"env:SCOPED", "--app-scope", "app2")
+	assert.NoError(t, err)
+
+	out = f.Run("var:get", "-p", projectID, "-l", "p", "env:SCOPED", "-P", "application_scope")
+	assert.Contains(t, out, "app2")
+}
+
+func TestVariableCreateWithAppScopeNoDeployment(t *testing.T) {
+	// Uses an environment without a deployment, so app-scope validation is skipped.
+	authServer := mockapi.NewAuthServer(t)
+	t.Cleanup(authServer.Close)
+
+	apiHandler := mockapi.NewHandler(t)
+	apiServer := httptest.NewServer(apiHandler)
+	t.Cleanup(apiServer.Close)
+
+	projectID := mockapi.ProjectID()
+
+	apiHandler.SetProjects([]*mockapi.Project{{
+		ID: projectID,
+		Links: mockapi.MakeHALLinks(
+			"self=/projects/"+projectID,
+			"environments=/projects/"+projectID+"/environments",
+		),
+		DefaultBranch: "main",
+	}})
+
+	main := makeEnv(projectID, "main", "production", "active", nil)
+	main.Links["#variables"] = mockapi.HALLink{HREF: "/projects/" + projectID + "/environments/main/variables"}
+	main.Links["#manage-variables"] = mockapi.HALLink{HREF: "/projects/" + projectID + "/environments/main/variables"}
+	apiHandler.SetEnvironments([]*mockapi.Environment{main})
+
+	f := newCommandFactory(t, apiServer.URL, authServer.URL)
+
+	_, stdErr, err := f.RunCombinedOutput("var:create", "-p", projectID, "-l", "p",
+		"env:ANY_APP", "--value", "val", "--app-scope", "anyapp")
+	assert.NoError(t, err)
+	assert.Contains(t, stdErr, "Creating variable env:ANY_APP")
+
+	out := f.Run("var:get", "-p", projectID, "-l", "p", "env:ANY_APP", "-P", "application_scope")
+	assert.Contains(t, out, "anyapp")
+}

--- a/legacy/src/Service/VariableCommandUtil.php
+++ b/legacy/src/Service/VariableCommandUtil.php
@@ -7,8 +7,11 @@ namespace Platformsh\Cli\Service;
 use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Selector\Selection;
 use Platformsh\Client\Model\ApiResourceBase;
+use Platformsh\Client\Model\Environment;
+use Platformsh\Client\Model\Project;
 use Platformsh\Client\Model\ProjectLevelVariable;
 use Platformsh\Client\Model\Variable as EnvironmentLevelVariable;
+use Platformsh\ConsoleForm\Field\ArrayField;
 use Platformsh\ConsoleForm\Field\BooleanField;
 use Platformsh\ConsoleForm\Field\Field;
 use Platformsh\ConsoleForm\Field\OptionsField;
@@ -170,6 +173,32 @@ class VariableCommandUtil
             'includeAsOption' => false,
             'defaultCallback' => fn(): ?string => $getSelection()->hasEnvironment() ? $getSelection()->getEnvironment()->id : null,
         ]);
+        $fields['application_scope'] = new ArrayField('Application scope', [
+            'optionName' => 'app-scope',
+            'description' => 'A list of application names to which this variable will apply.',
+            'questionLine' => 'To which applications should this variable apply?',
+            'default' => [],
+            'required' => false,
+            'avoidQuestion' => true,
+            'validator' => function ($values) use ($getSelection): bool {
+                $selection = $getSelection();
+                $appNames = $this->listApps($selection->getProject(), $selection->hasEnvironment() ? $selection->getEnvironment() : null);
+                if ($appNames === false) {
+                    // No app names available: skip validation.
+                    return true;
+                }
+                foreach ($values as $value) {
+                    if (!in_array($value, $appNames, true)) {
+                        throw new InvalidArgumentException(sprintf(
+                            'The app "%s" was not found. Valid app names are: %s',
+                            $value,
+                            implode(', ', $appNames),
+                        ));
+                    }
+                }
+                return true;
+            },
+        ]);
         $fields['name'] = new Field('Name', [
             'description' => 'The variable name',
             'validators' => [
@@ -255,5 +284,28 @@ class VariableCommandUtil
             'none' => 'No prefix: The variable will be part of <comment>$' . $this->config->getStr('service.env_prefix') . 'VARIABLES</comment>.',
             'env:' => 'env: The variable will be exposed directly, e.g. as <comment>$' . strtoupper($name) . '</comment>.',
         ];
+    }
+
+    /**
+     * Lists application names for validating application_scope values.
+     *
+     * @return string[]|false An array of app names, or false if they could not be determined.
+     */
+    private function listApps(Project $project, ?Environment $environment = null): array|false
+    {
+        if (!$environment) {
+            if ($project->default_branch !== '') {
+                $environment = $this->api->getEnvironment($project->default_branch, $project) ?: null;
+            }
+            if (!$environment) {
+                return false;
+            }
+        }
+        try {
+            $deployment = $this->api->getCurrentDeployment($environment);
+        } catch (\Exception) {
+            return false;
+        }
+        return array_keys($deployment->webapps);
     }
 }

--- a/legacy/src/Service/VariableCommandUtil.php
+++ b/legacy/src/Service/VariableCommandUtil.php
@@ -294,7 +294,7 @@ class VariableCommandUtil
     private function listApps(Project $project, ?Environment $environment = null): array|false
     {
         if (!$environment) {
-            if ($project->default_branch !== '') {
+            if (\is_string($project->default_branch) && $project->default_branch !== '') {
                 $environment = $this->api->getEnvironment($project->default_branch, $project) ?: null;
             }
             if (!$environment) {


### PR DESCRIPTION
Reimplemented from platformsh/legacy-cli#1590 against the 5.x architecture in `legacy/`.

Adds `--app-scope` to `var:create` and `var:update`, allowing variables to be scoped to specific applications within a project. The option accepts multiple values (`--app-scope app1 --app-scope app2`), validates app names against the current deployment when one is available, and skips validation when no deployment exists (e.g. inactive environments). The `application_scope` property already shows in `variable:get` output without further code changes.

The original PR's diff did not apply because:

- The 5.x `legacy/` tree has no `Command/Variable/VariableCommandBase.php`; variable form fields now live in `Service/VariableCommandUtil::getFields()`. The new `application_scope` `ArrayField` was added there, with the validator using the lazy `$getSelection()` callable to reach the project/environment.
- The `listApps()` helper was added as a private method on the same service, calling `$this->api->getCurrentDeployment()` (now a 2-arg signature in 5.x) and catching exceptions in place of the old "throw=false" flag.
- The integration tests were ported from the now-deleted `go-tests/` directory to `integration-tests/variable_write_test.go`, using `t.Cleanup` and the existing `mockapi` helpers (`SetCurrentDeployment`, `MakeHALLinks`).