### PR TITLE
fix(activity:log): drop stray query params from log stream URL

### DIFF
--- a/legacy/src/Service/ActivityMonitor.php
+++ b/legacy/src/Service/ActivityMonitor.php
@@ -685,6 +685,13 @@ class ActivityMonitor
     {
         $url = $activity->getLink('log');
 
+        // Strip any query string from the URL. The log link can inherit query
+        // parameters (such as "count") from the base activities collection
+        // URL, and those are rejected by the log endpoint with HTTP 400.
+        if (($queryPos = \strpos($url, '?')) !== false) {
+            $url = \substr($url, 0, $queryPos);
+        }
+
         // Try fetching the stream with a 10 second timeout per call, and a .5
         // second interval between calls, for up to 2 minutes.
         $readTimeout = 10;

--- a/legacy/src/Service/ActivityMonitor.php
+++ b/legacy/src/Service/ActivityMonitor.php
@@ -712,7 +712,7 @@ class ActivityMonitor
                 throw new \RuntimeException('Failed to open activity log stream: ' . $url);
             }
             $bar->advance();
-            \usleep((int) $interval * 1000000);
+            \usleep((int) ($interval * 1000000));
             $bar->advance();
             $stream = \fopen($url, 'r', false, $this->api->getStreamContext($readTimeout));
         }


### PR DESCRIPTION
## Summary

When `activity:log` (or any waited activity) opens its log stream, the URL it `fopen`s comes from `Platformsh\Client\Model\Activity::getLink('log')`. The client library's `ApiResourceBase::makeAbsoluteUrl()` resolves the relative log link against the activity's base URL by swapping in the relative target's path, but keeps the base's query string. So when the activity was loaded via `/projects/<id>/activities?count=1` (e.g. `--all`, or any default-activity selection), the resulting log URL is `.../activities/<id>/log?count=1`.

The log endpoint rejects `count` with HTTP 400. Without verbose mode the `fopen` warning is hidden, but the streaming retry loop in `ActivityMonitor::getLogStream()` still spins until its 2-minute timeout. With `-vv`, the user sees a flood of `Warning: fopen(...): Failed to open stream: HTTP request failed! HTTP/1.1 400 Bad Request`.

This PR works around the issue in the legacy CLI by stripping the query string from the log URL before opening the stream. The non-streaming `Activity::readLog()` path goes through Guzzle with the `query` request option, which already replaces the URL's query string, and is unaffected.

A second commit fixes a long-standing operator-precedence bug in the same retry loop: `(int) $interval * 1000000` evaluated as `((int) 0.5) * 1000000 = 0`, so `usleep(0)` was called instead of the intended 0.5-second sleep, causing the loop to spin as fast as PHP could re-issue `fopen` on the failing endpoint. Wrapping the multiplication in parentheses restores the intended delay.

The underlying link-resolution bug should also be fixed upstream in `platformsh-client-php`; that's tracked separately.