### PR TITLE
fix(activity:list): handle null result on in-progress activities

### DIFF
--- a/legacy/phpstan-stubs/Activity.stub
+++ b/legacy/phpstan-stubs/Activity.stub
@@ -1,0 +1,32 @@
+<?php
+
+namespace Platformsh\Client\Model;
+
+/**
+ * Local PHPStan stub for the Activity model.
+ *
+ * The upstream docblock types properties as non-nullable strings, but the API
+ * returns null for several properties until the activity reaches a particular
+ * state (e.g. result is null until the activity finishes).
+ *
+ * @property-read string      $id
+ * @property-read int         $completion_percent
+ * @property-read string      $log
+ * @property-read string      $created_at
+ * @property-read string      $updated_at
+ * @property-read string[]    $environments
+ * @property-read string|null $completed_at
+ * @property-read array       $parameters
+ * @property-read string      $project
+ * @property-read string      $state
+ * @property-read string|null $result
+ * @property-read string|null $started_at
+ * @property-read string      $type
+ * @property-read string      $description
+ * @property-read string      $text
+ * @property-read array       $payload
+ * @property-read array       $commands
+ */
+class Activity
+{
+}

--- a/legacy/phpstan-stubs/Activity.stub
+++ b/legacy/phpstan-stubs/Activity.stub
@@ -7,24 +7,30 @@ namespace Platformsh\Client\Model;
  *
  * The upstream docblock types properties as non-nullable strings, but the API
  * returns null for several properties until the activity reaches a particular
- * state (e.g. result is null until the activity finishes).
+ * state (e.g. result is null until the activity finishes). The list and
+ * nullability here follow the Upsun OpenAPI spec
+ * (https://developer.upsun.com/openapi.json).
  *
  * @property-read string      $id
  * @property-read int         $completion_percent
  * @property-read string      $log
- * @property-read string      $created_at
- * @property-read string      $updated_at
+ * @property-read string|null $created_at
+ * @property-read string|null $updated_at
  * @property-read string[]    $environments
+ * @property-read string|null $started_at
  * @property-read string|null $completed_at
+ * @property-read string|null $cancelled_at
+ * @property-read string|null $expires_at
  * @property-read array       $parameters
  * @property-read string      $project
+ * @property-read string|null $integration
  * @property-read string      $state
  * @property-read string|null $result
- * @property-read string|null $started_at
  * @property-read string      $type
- * @property-read string      $description
- * @property-read string      $text
+ * @property-read string|null $description
+ * @property-read string|null $text
  * @property-read array       $payload
+ * @property-read array       $timings
  * @property-read array       $commands
  */
 class Activity

--- a/legacy/phpstan.neon
+++ b/legacy/phpstan.neon
@@ -10,6 +10,8 @@ parameters:
 		- dist/installer.php
 	excludePaths:
 		- dist/installer.php
+	stubFiles:
+		- phpstan-stubs/Activity.stub
 
 includes:
 	- phpstan-baseline.neon

--- a/legacy/src/Service/ActivityMonitor.php
+++ b/legacy/src/Service/ActivityMonitor.php
@@ -592,7 +592,8 @@ class ActivityMonitor
      */
     public static function formatResult(Activity $activity, bool $decorate = true): string
     {
-        $result = $activity->result;
+        // The result is null until the activity has finished.
+        $result = $activity->result ?? '';
         $name = self::RESULT_NAMES[$result] ?? $result;
 
         foreach ($activity->commands ?? [] as $command) {

--- a/legacy/tests/Service/ActivityMonitorTest.php
+++ b/legacy/tests/Service/ActivityMonitorTest.php
@@ -26,7 +26,7 @@ class ActivityMonitorTest extends TestCase
     public function testFormatResultNull(): void
     {
         // An in-progress activity has no result yet.
-        $activity = new Activity(['id' => 'a', 'state' => Activity::STATE_IN_PROGRESS]);
+        $activity = new Activity(['id' => 'a', 'state' => Activity::STATE_IN_PROGRESS, 'result' => null]);
         $this->assertSame('', ActivityMonitor::formatResult($activity, false));
         $this->assertSame('', ActivityMonitor::formatResult($activity, true));
     }
@@ -50,6 +50,7 @@ class ActivityMonitorTest extends TestCase
         $activity = new Activity([
             'id' => 'a',
             'state' => Activity::STATE_IN_PROGRESS,
+            'result' => null,
             'commands' => [
                 ['exit_code' => 1],
             ],

--- a/legacy/tests/Service/ActivityMonitorTest.php
+++ b/legacy/tests/Service/ActivityMonitorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Platformsh\Cli\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Platformsh\Cli\Service\ActivityMonitor;
+use Platformsh\Client\Model\Activity;
+
+class ActivityMonitorTest extends TestCase
+{
+    public function testFormatResultSuccess(): void
+    {
+        $activity = new Activity(['id' => 'a', 'result' => Activity::RESULT_SUCCESS]);
+        $this->assertSame('success', ActivityMonitor::formatResult($activity, false));
+    }
+
+    public function testFormatResultFailure(): void
+    {
+        $activity = new Activity(['id' => 'a', 'result' => Activity::RESULT_FAILURE]);
+        $this->assertSame('failure', ActivityMonitor::formatResult($activity, false));
+        $this->assertSame('<error>failure</error>', ActivityMonitor::formatResult($activity, true));
+    }
+
+    public function testFormatResultNull(): void
+    {
+        // An in-progress activity has no result yet.
+        $activity = new Activity(['id' => 'a', 'state' => Activity::STATE_IN_PROGRESS]);
+        $this->assertSame('', ActivityMonitor::formatResult($activity, false));
+        $this->assertSame('', ActivityMonitor::formatResult($activity, true));
+    }
+
+    public function testFormatResultFailedCommandOverridesSuccess(): void
+    {
+        $activity = new Activity([
+            'id' => 'a',
+            'result' => Activity::RESULT_SUCCESS,
+            'commands' => [
+                ['exit_code' => 0],
+                ['exit_code' => 1],
+            ],
+        ]);
+        $this->assertSame('failure', ActivityMonitor::formatResult($activity, false));
+        $this->assertSame('<error>failure</error>', ActivityMonitor::formatResult($activity, true));
+    }
+
+    public function testFormatResultFailedCommandWithNullResult(): void
+    {
+        $activity = new Activity([
+            'id' => 'a',
+            'state' => Activity::STATE_IN_PROGRESS,
+            'commands' => [
+                ['exit_code' => 1],
+            ],
+        ]);
+        $this->assertSame('failure', ActivityMonitor::formatResult($activity, false));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #57. `ActivityMonitor::formatResult()` threw a `TypeError` when invoked on an activity whose `result` was `null` (i.e. still in progress). The bug surfaced after upstream legacy-cli #1572 changed the signature to take an `Activity` object instead of the `string` result and started reading `$activity->result` internally.

The fix coerces a missing result to an empty string before the result-name lookup so the function always returns a string. An empty `result` column in `activity:list` for in-progress activities matches the column's prior behavior.

## Changes

- `legacy/src/Service/ActivityMonitor.php` - guard against null `$activity->result`.
- `legacy/tests/Service/ActivityMonitorTest.php` - new unit tests covering success, failure, null/in-progress, and failed-command-override paths.
- `legacy/phpstan-stubs/Activity.stub` + `legacy/phpstan.neon` - local PHPStan stub that marks `result`, `completed_at` and `started_at` as `?string`. The upstream client docblock has them as non-null `string`, which is why PHPStan did not catch this. With the stub in place, running PHPStan at level 8 flags the original bug (and the equivalent fix passes); the project still runs at level 7 by default.