### PR TITLE
fix(variable:create): suppress spurious "Variable not found" message

### DIFF
--- a/integration-tests/variable_write_test.go
+++ b/integration-tests/variable_write_test.go
@@ -70,12 +70,16 @@ func TestVariableCreate(t *testing.T) {
 	_, stdErr, err := f.RunCombinedOutput("var:create", "-p", p, "-l", "e", "-e", "main", "env:TEST", "--value", "env-level-value")
 	assert.NoError(t, err)
 	assert.Contains(t, stdErr, "Creating variable env:TEST on the environment main")
+	// Regression: var:create must not print "Variable not found" when the
+	// variable does not yet exist.
+	assert.NotContains(t, stdErr, "Variable not found")
 
 	assertTrimmed(t, "env-level-value", f.Run("var:get", "-p", p, "-e", "main", "env:TEST", "-P", "value"))
 
 	_, stdErr, err = f.RunCombinedOutput("var:create", "-p", p, "env:TEST", "-l", "p", "--value", "project-level-value")
 	assert.NoError(t, err)
 	assert.Contains(t, stdErr, "Creating variable env:TEST on the project "+p)
+	assert.NotContains(t, stdErr, "Variable not found")
 
 	assertTrimmed(t, "project-level-value", f.Run("var:get", "-p", p, "-e", "main", "env:TEST", "-P", "value", "-l", "p"))
 	assertTrimmed(t, "env-level-value", f.Run("var:get", "-p", p, "-e", "main", "env:TEST", "-P", "value", "-l", "e"))

--- a/legacy/src/Command/Variable/VariableCreateCommand.php
+++ b/legacy/src/Command/Variable/VariableCreateCommand.php
@@ -79,7 +79,7 @@ class VariableCreateCommand extends CommandBase
             if (($prefix = $input->getOption('prefix')) && $prefix !== 'none') {
                 $name = rtrim((string) $prefix, ':') . ':' . $name;
             }
-            $existing = $this->variableCommandUtil->getExistingVariable($name, $selection, $this->variableCommandUtil->getRequestedLevel($input));
+            $existing = $this->variableCommandUtil->getExistingVariable($name, $selection, $this->variableCommandUtil->getRequestedLevel($input), false);
             if ($existing) {
                 if (!$input->getOption('update')) {
                     $this->stdErr->writeln('The variable already exists: <error>' . $name . '</error>');


### PR DESCRIPTION
## Summary

`upsun variable:create` printed `Variable not found: <name>` to stderr immediately before `Creating variable ...` when the variable did not yet exist, making the success path look like a failure.

The cause is in `VariableCreateCommand`, which looks up the variable up-front so it can short-circuit to `variable:update` when `--update` is given. That lookup uses `VariableCommandUtil::getExistingVariable()`, whose `\$messages` argument defaults to `true` — so absence is reported to stderr. For `variable:create`, absence is the success precondition, not a failure.

Fix: pass `false` for `\$messages` at the create call site. The other callers (`get`, `delete`, `update`) genuinely treat absence as a failure and continue to use the default.

Adds integration-test assertions in `TestVariableCreate` covering both the environment-level and project-level create paths.