### PR TITLE
fix(legacy): ignore host php.ini when invoking embedded PHP

### DIFF
--- a/internal/legacy/legacy.go
+++ b/internal/legacy/legacy.go
@@ -165,7 +165,12 @@ func (c *CLIWrapper) Exec(ctx context.Context, args ...string) error {
 func (c *CLIWrapper) makeCmd(ctx context.Context, args []string, cacheDir string) *exec.Cmd {
 	phpMgr := newPHPManager(cacheDir)
 	settings := phpMgr.settings()
-	var cmdArgs = make([]string, 0, len(args)+2+len(settings)*2)
+	// "-n" tells PHP to ignore any php.ini and scan directory on the host.
+	// The embedded PHP binary is statically built with all extensions it
+	// needs compiled in, and cannot load shared extensions referenced by a
+	// system php.ini (e.g. inside Lando containers).
+	var cmdArgs = make([]string, 0, len(args)+3+len(settings)*2)
+	cmdArgs = append(cmdArgs, "-n")
 	for _, s := range settings {
 		cmdArgs = append(cmdArgs, "-d", s)
 	}

--- a/internal/legacy/legacy_test.go
+++ b/internal/legacy/legacy_test.go
@@ -19,6 +19,8 @@ import (
 func TestMakeCmdIgnoresSystemPHPIni(t *testing.T) {
 	w := &CLIWrapper{Config: &config.Config{}}
 	w.Config.Application.Executable = "platform-test"
+	// Isolate from any host env: pharPath() reads {EnvPrefix}PHAR_PATH.
+	w.Config.Application.EnvPrefix = "TEST_MAKECMD_"
 
 	cmd := w.makeCmd(context.Background(), []string{"help"}, t.TempDir())
 

--- a/internal/legacy/legacy_test.go
+++ b/internal/legacy/legacy_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -14,6 +15,22 @@ import (
 
 	"github.com/upsun/cli/internal/config"
 )
+
+func TestMakeCmdIgnoresSystemPHPIni(t *testing.T) {
+	w := &CLIWrapper{Config: &config.Config{}}
+	w.Config.Application.Executable = "platform-test"
+
+	cmd := w.makeCmd(context.Background(), []string{"help"}, t.TempDir())
+
+	// The "-n" flag must be present and precede the phar path so that PHP
+	// ignores any host php.ini before the script runs.
+	idxN := slices.Index(cmd.Args, "-n")
+	require.GreaterOrEqual(t, idxN, 1, "expected -n in PHP args: %v", cmd.Args)
+	pharIdx := slices.IndexFunc(cmd.Args, func(s string) bool {
+		return strings.HasSuffix(s, ".phar")
+	})
+	require.Greater(t, pharIdx, idxN, "-n must come before the phar path")
+}
 
 func TestLegacyCLI(t *testing.T) {
 	if len(phar) == 0 || len(phpCLI) == 0 {
@@ -70,4 +87,25 @@ func TestLegacyCLI(t *testing.T) {
 	err = wrapper.Exec(context.Background(), "--version")
 	assert.NoError(t, err)
 	assert.Equal(t, "Test CLI "+testCLIVersion, strings.TrimSuffix(stdout.String(), "\n"))
+
+	// Simulate a host-PHP config that would cause warnings on a static binary
+	// (as in Lando containers): an ini that tries to dlopen extensions which
+	// the embedded static PHP cannot load. With "-n" passed to PHP, the host
+	// ini must be ignored entirely and produce no startup warnings.
+	iniPath := filepath.Join(tempDir, "php.ini")
+	require.NoError(t, os.WriteFile(iniPath, []byte(
+		"extension=pdo_mysql\nextension=opcache\nextension=bcmath\n",
+	), 0o644))
+	t.Setenv("PHPRC", iniPath)
+	t.Setenv("PHP_INI_SCAN_DIR", tempDir)
+
+	stdout.Reset()
+	capturedErr := &bytes.Buffer{}
+	wrapper.Stderr = capturedErr
+	err = wrapper.Exec(context.Background(), "--version")
+	wrapper.Stderr = stdErr
+	assert.NoError(t, err)
+	combined := stdout.String() + capturedErr.String()
+	assert.NotContains(t, combined, "Unable to load dynamic library")
+	assert.NotContains(t, combined, "Failed loading")
 }


### PR DESCRIPTION
## Summary

When the CLI runs inside an environment that ships its own PHP configuration (for example Lando containers, where `PHPRC` or `/usr/local/etc/php/` references extensions like `pdo_mysql`, `opcache`, `bcmath`, etc.), the embedded static PHP binary emitted a startup warning per extension before every command:

```
Warning: PHP Startup: Unable to load dynamic library 'pdo_mysql' (tried: /lib/php/extensions/no-debug-non-zts-20240924/pdo_mysql (Dynamic loading not supported), /lib/php/extensions/no-debug-non-zts-20240924/pdo_mysql.so (Dynamic loading not supported)) in Unknown on line 0
```

The static binary has every extension the legacy CLI uses (`curl`, `filter`, `openssl`, `pcntl`, `phar`, `posix`, `zlib`) compiled in and cannot `dlopen` shared extensions, so any host `php.ini` is both useless and noisy.

This regressed when the CLI moved to externally built static PHP binaries; the previous packaging happened to avoid the system search paths.

## Fix

Pass `-n` to the embedded PHP binary in `makeCmd`. `-n` tells PHP to skip the main `php.ini` and the scan directory entirely, regardless of `PHPRC` / `PHP_INI_SCAN_DIR`. The existing `-d` settings (`openssl.cafile` on Windows) still apply because they are command-line arguments.

There is no equivalent build-time option in static-php-cli: `--with-config-file-path` and `--with-config-file-scan-dir` only change defaults, and `PHPRC` / `PHP_INI_SCAN_DIR` always override them at runtime.

## Tests

- New unit test pinning `-n` in the args produced by `makeCmd`.
- Extended `TestLegacyCLI` to point `PHPRC` and `PHP_INI_SCAN_DIR` at an ini that references extensions the static binary cannot load, then asserts no "Unable to load dynamic library" warnings appear in stdout or stderr. Verified to fail without `-n` and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)