### PR TITLE
ci(release): trigger only on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,6 @@ on:
   push:
     tags:
       - "v[0-9]*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to release (must already be pushed, e.g. v5.10.0-rc1)"
-        required: true
-      upload_taps:
-        description: "Upload to Homebrew/Scoop taps (overrides pre-release skip)"
-        type: boolean
-        default: false
-      upload_repos:
-        description: "Upload to package repositories via repogen (overrides pre-release skip)"
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -37,8 +24,9 @@ jobs:
     steps:
       - name: Resolve tag
         id: tag
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
           if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
             echo "::error::Tag '$TAG' does not match semver format (vMAJOR.MINOR.PATCH)"
             exit 1
@@ -125,15 +113,13 @@ jobs:
 
       - name: Generate GitHub App token for homebrew-tap
         id: app-token
-        if: startsWith(github.ref, 'refs/tags/') || inputs.tag
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: homebrew-tap
 
-      - name: Build release (tag)
-        if: startsWith(github.ref, 'refs/tags/') || inputs.tag
+      - name: Build release
         env:
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -141,18 +127,11 @@ jobs:
           RSA_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/rsa-signing-key.pem
           GPG_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/gpg-signing-key.asc
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
-          SKIP_UPLOAD_TAPS: ${{ inputs.upload_taps == true && 'false' || 'auto' }}
+          SKIP_UPLOAD_TAPS: auto
         run: make release
 
-      - name: Build snapshot (branch)
-        if: "!startsWith(github.ref, 'refs/tags/') && !inputs.tag"
-        env:
-          RSA_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/rsa-signing-key.pem
-          GPG_SIGNING_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/gpg-signing-key.asc
-        run: make snapshot
-
       - name: Configure AWS credentials
-        if: steps.tag.outputs.is_prerelease == 'false' || inputs.upload_repos == true
+        if: steps.tag.outputs.is_prerelease == 'false'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -160,7 +139,7 @@ jobs:
           aws-region: eu-west-1
 
       - name: Upload packages to repository
-        if: steps.tag.outputs.is_prerelease == 'false' || inputs.upload_repos == true
+        if: steps.tag.outputs.is_prerelease == 'false'
         env:
           GPG_PRIVATE_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/gpg-signing-key.asc
           RSA_PRIVATE_KEY_FILE: ${{ steps.signing-keys.outputs.key_dir }}/rsa-signing-key.pem


### PR DESCRIPTION
## Summary

- Remove the `workflow_dispatch` trigger and its inputs (`tag`, `upload_taps`, `upload_repos`). The release workflow now runs solely from a `v*` tag push, which is already gated by the tag ruleset.
- Read `github.ref_name` via an `env:` block in the "Resolve tag" step instead of interpolating it directly into the run script.
- Drop the now-dead conditionals on `inputs.tag` and `inputs.upload_repos`, and the unreachable "Build snapshot (branch)" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)