### PR TITLE
fix(legacy): cast team:project:add input to string before exploding

### DIFF
--- a/legacy/src/Command/Team/Project/TeamProjectAddCommand.php
+++ b/legacy/src/Command/Team/Project/TeamProjectAddCommand.php
@@ -122,7 +122,7 @@ class TeamProjectAddCommand extends TeamCommandBase
                 $first = true;
                 do {
                     $choice = $this->questionHelper->askInput($questionText, null, array_values($autocomplete), function ($value) use ($autocomplete, $first, $teamProjectIds): ?string {
-                        [$id, ] = explode(' - ', $value);
+                        [$id, ] = explode(' - ', (string) $value);
                         if (empty(trim($id))) {
                             if (!$first) {
                                 return null;

--- a/legacy/src/Command/Team/Project/TeamProjectAddCommand.php
+++ b/legacy/src/Command/Team/Project/TeamProjectAddCommand.php
@@ -122,7 +122,7 @@ class TeamProjectAddCommand extends TeamCommandBase
                 $first = true;
                 do {
                     $choice = $this->questionHelper->askInput($questionText, null, array_values($autocomplete), function ($value) use ($autocomplete, $first, $teamProjectIds): ?string {
-                        [$id, ] = explode(' - ', (string) $value);
+                        [$id] = explode(' - ', (string) $value, 2);
                         if (empty(trim($id))) {
                             if (!$first) {
                                 return null;


### PR DESCRIPTION
## Summary

When running `team:project:add` interactively and pressing Enter to finish project selection, the CLI crashed with:

```
Fatal error: Uncaught TypeError: explode(): Argument #2 ($string) must be of type string, null given
```

Symfony passes `null` to the validator when the user accepts the question's default (which is `null` here). PHP 8 disallows `null` as the second argument to `explode()`. The existing `empty(trim($id))` check below already handles the empty case correctly — casting `(string) $value` is enough to restore the intended "Enter to finish" behavior.