### PR TITLE
fix(tunnel:single): Windows port type error and stuck state

### DIFF
--- a/legacy/src/Command/Tunnel/TunnelSingleCommand.php
+++ b/legacy/src/Command/Tunnel/TunnelSingleCommand.php
@@ -12,6 +12,7 @@ use Platformsh\Cli\Service\Relationships;
 use Platformsh\Cli\Service\Ssh;
 use Platformsh\Cli\Console\ProcessManager;
 use Platformsh\Cli\Service\TunnelManager;
+use Platformsh\Cli\Util\OsUtil;
 use Platformsh\Cli\Util\PortUtil;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -81,24 +82,32 @@ class TunnelSingleCommand extends TunnelCommandBase
         }
         $sshArgs = $this->ssh->getSshArgs($sshUrl, $sshOptions);
 
-        if ($localPort = $input->getOption('port')) {
-            if (!PortUtil::validatePort($localPort)) {
-                $this->stdErr->writeln(sprintf('Invalid port: <error>%s</error>', $localPort));
+        $localPort = null;
+        if ($portOption = $input->getOption('port')) {
+            if (!PortUtil::validatePort($portOption)) {
+                $this->stdErr->writeln(sprintf('Invalid port: <error>%s</error>', $portOption));
 
                 return 1;
             }
-            if (PortUtil::isPortInUse($localPort)) {
-                $this->stdErr->writeln(sprintf('Port already in use: <error>%s</error>', $localPort));
+            if (PortUtil::isPortInUse($portOption)) {
+                $this->stdErr->writeln(sprintf('Port already in use: <error>%s</error>', $portOption));
 
                 return 1;
             }
+            $localPort = (int) $portOption;
         }
 
         $tunnel = $this->tunnelManager->create($selection, $service, $localPort);
 
         $relationshipString = $this->tunnelManager->formatRelationship($tunnel);
 
-        if ($openTunnelInfo = $this->tunnelManager->isOpen($tunnel)) {
+        // The persistent tunnel state used by tunnel:list/info/close depends on
+        // POSIX signals to detect dead processes. On Windows that detection is
+        // unavailable, so stale entries would never be cleaned up. Since this
+        // command runs in the foreground anyway, skip the state on Windows.
+        $trackState = !OsUtil::isWindows();
+
+        if ($trackState && ($openTunnelInfo = $this->tunnelManager->isOpen($tunnel))) {
             $this->stdErr->writeln(sprintf(
                 'A tunnel is already opened to the relationship <info>%s</info>, at: <info>%s</info>',
                 $relationshipString,
@@ -127,7 +136,9 @@ class TunnelSingleCommand extends TunnelCommandBase
             return 1;
         }
 
-        $this->tunnelManager->saveNewTunnel($tunnel, $pid);
+        if ($trackState) {
+            $this->tunnelManager->saveNewTunnel($tunnel, $pid);
+        }
 
         if ($output->isVerbose()) {
             // Just an extra line for separation from the process manager's log.


### PR DESCRIPTION
## Summary

Two bugs reported against `upsun tunnel:single` on Windows in CLI 5.10.4:

**1. `--port` causes a fatal TypeError.**
`InputOption::VALUE_REQUIRED` returns the value as a string, but `TunnelManager::create()` is typed `?int`, so `upsun tunnel:single --port 30005` crashed with:

> `TunnelManager::create(): Argument #3 ($localPort) must be of type ?int, string given`

Now the option is validated as a string (the validators accept `int|string`) and cast to `int` before being passed on.

**2. Tunnel state gets stuck after the first run.**
The persistent state in `tunnel-info.json` is cleaned up via `posix_kill($pid, 0)`, which doesn't exist on Windows. So once a tunnel was recorded, the entry was never removed, and the next `tunnel:single` exited with "A tunnel is already opened" forever.

Since `tunnel:single` runs in the foreground on Windows (the background `tunnel:open` is explicitly disabled there), the persistent state isn't really useful — `tunnel:list`/`info`/`close` only make sense when the tunnel command has already returned. The fix skips both the `isOpen()` check and `saveNewTunnel()` on Windows, so no state is written and there's nothing to get stuck.

Existing stale entries in users' `tunnel-info.json` become harmless after this change — they're never read by `tunnel:single` on Windows.