### PR TITLE
fix(tunnel:open): cast remote port to int

### DIFF
--- a/legacy/src/Service/TunnelManager.php
+++ b/legacy/src/Service/TunnelManager.php
@@ -51,7 +51,9 @@ class TunnelManager
             'service' => $service,
         ];
 
-        return new Tunnel($this->getId($metadata), $localPort ?: $this->getPort(), $service['host'], $service['port'], $metadata);
+        // The 'port' value from the API relationship metadata is a string, but
+        // Tunnel expects an int, so cast it here.
+        return new Tunnel($this->getId($metadata), $localPort ?: $this->getPort(), $service['host'], (int) $service['port'], $metadata);
     }
 
     /**

--- a/legacy/tests/Service/TunnelManagerTest.php
+++ b/legacy/tests/Service/TunnelManagerTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Platformsh\Cli\Tests\Service;
 
 use PHPUnit\Framework\TestCase;
+use Platformsh\Cli\Selector\Selection;
 use Platformsh\Cli\Service\Config;
 use Platformsh\Cli\Service\Io;
 use Platformsh\Cli\Service\Relationships;
 use Platformsh\Cli\Service\TunnelManager;
 use Platformsh\Cli\Tunnel\Tunnel;
+use Platformsh\Client\Model\Environment;
+use Platformsh\Client\Model\Project;
 
 class TunnelManagerTest extends TestCase
 {
@@ -93,6 +96,29 @@ class TunnelManagerTest extends TestCase
         $this->assertSame('web', $tunnel->metadata['appName']);
         $this->assertSame('redis', $tunnel->metadata['relationship']);
         $this->assertSame(1, $tunnel->metadata['serviceKey']);
+    }
+
+    public function testCreateCastsRemotePortToInt(): void
+    {
+        // Relationship data from the API delivers 'port' as a string, but
+        // Tunnel::$remotePort is typed int. Regression test for #72.
+        $selection = new Selection(
+            null,
+            new Project(['id' => 'proj1']),
+            new Environment(['id' => 'main']),
+            'app',
+        );
+        $service = [
+            'host' => 'database.internal',
+            'port' => '3306',
+            '_relationship_name' => 'database',
+            '_relationship_key' => 0,
+        ];
+
+        $tunnel = $this->createManager()->create($selection, $service, 30000);
+
+        $this->assertSame(3306, $tunnel->remotePort);
+        $this->assertSame(30000, $tunnel->localPort);
     }
 
     public function testUnserializeOldFormatDerivedIdIsStable(): void


### PR DESCRIPTION
## Summary

`upsun tunnel:open` crashes with a fatal `TypeError` before the tunnel is created:

> `Tunnel::__construct(): Argument #4 ($remotePort) must be of type int, string given`

The `port` value in the relationship metadata returned by the API arrives as a string. `Tunnel::__construct` types `$remotePort` as `int`, so constructing the `Tunnel` blows up at `TunnelManager.php:54`.

Fix: cast `$service['port']` to `int` at the call site. Added a regression test that reproduces the exact failure from #72 without the fix and passes with it.

Closes #72.

Note: PR #89 fixed the sibling `$localPort` cast for `tunnel:single --port` on Windows, but didn't touch the `$remotePort` path used by `tunnel:open`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)