### PR TITLE
feat(ssh-cert): support configurable key algorithm for FIPS hosts

### DIFF
--- a/integration-tests/ssh_cert_test.go
+++ b/integration-tests/ssh_cert_test.go
@@ -20,8 +20,11 @@ func TestSSHCerts(t *testing.T) {
 	apiServer := httptest.NewServer(apiHandler)
 	defer apiServer.Close()
 
-	t.Run("default ed25519", func(t *testing.T) {
+	// The algorithm is set explicitly in each subtest so that expectations do
+	// not depend on the runner's FIPS mode (which the "auto" default detects).
+	t.Run("explicit ed25519", func(t *testing.T) {
 		f := newCommandFactory(t, apiServer.URL, authServer.URL)
+		f.extraEnv = []string{EnvPrefix + "SSH_CERT_KEY_ALGORITHM=ed25519"}
 
 		output := f.Run("ssh-cert:info")
 		assert.Regexp(t, `(?m)^filename: .+?id_ed25519-cert\.pub$`, output)

--- a/integration-tests/ssh_cert_test.go
+++ b/integration-tests/ssh_cert_test.go
@@ -20,10 +20,24 @@ func TestSSHCerts(t *testing.T) {
 	apiServer := httptest.NewServer(apiHandler)
 	defer apiServer.Close()
 
-	f := newCommandFactory(t, apiServer.URL, authServer.URL)
+	t.Run("default ed25519", func(t *testing.T) {
+		f := newCommandFactory(t, apiServer.URL, authServer.URL)
 
-	output := f.Run("ssh-cert:info")
-	assert.Regexp(t, `(?m)^filename: .+?id_ed25519-cert\.pub$`, output)
-	assert.Contains(t, output, "key_id: test-key-id\n")
-	assert.Contains(t, output, "key_type: ssh-ed25519-cert-v01@openssh.com\n")
+		output := f.Run("ssh-cert:info")
+		assert.Regexp(t, `(?m)^filename: .+?id_ed25519-cert\.pub$`, output)
+		assert.Contains(t, output, "key_id: test-key-id\n")
+		assert.Contains(t, output, "key_type: ssh-ed25519-cert-v01@openssh.com\n")
+	})
+
+	// An explicit algorithm (e.g. for FIPS hosts where ed25519 is unavailable)
+	// produces a certificate over that key type.
+	t.Run("explicit rsa", func(t *testing.T) {
+		f := newCommandFactory(t, apiServer.URL, authServer.URL)
+		f.extraEnv = []string{EnvPrefix + "SSH_CERT_KEY_ALGORITHM=rsa"}
+
+		output := f.Run("ssh-cert:info")
+		assert.Regexp(t, `(?m)^filename: .+?id_rsa-cert\.pub$`, output)
+		assert.Contains(t, output, "key_id: test-key-id\n")
+		assert.Contains(t, output, "key_type: ssh-rsa-cert-v01@openssh.com\n")
+	})
 }

--- a/legacy/config-defaults.yaml
+++ b/legacy/config-defaults.yaml
@@ -333,6 +333,15 @@ ssh:
   # often provides a weak security benefit.
   cert_key_ttl: 86400
 
+  # The key algorithm used for the temporary SSH key pair generated when
+  # requesting an SSH certificate. Accepts any "ssh-keygen -t" type, e.g.
+  # ed25519 or rsa.
+  #
+  # The default "auto" detects FIPS mode: ed25519 is not available on FIPS-mode
+  # systems, so rsa is used there and ed25519 elsewhere. Setting an explicit
+  # algorithm disables detection and uses that algorithm directly.
+  cert_key_algorithm: 'auto'
+
 # How the CLI detects and configures Git repositories as projects.
 detection:
   ## Required keys that must be defined elsewhere:

--- a/legacy/src/SshCert/Certifier.php
+++ b/legacy/src/SshCert/Certifier.php
@@ -15,8 +15,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Certifier
 {
-    public const KEY_ALGORITHM = 'ed25519';
-    public const PRIVATE_KEY_FILENAME = 'id_ed25519';
+    private const FIPS_FILE = '/proc/sys/crypto/fips_enabled';
+
     private readonly OutputInterface $stdErr;
 
     private static bool $disableAutoLoad = false;
@@ -83,7 +83,7 @@ class Certifier
         $dir = $this->config->getSessionDir(true) . DIRECTORY_SEPARATOR . 'ssh';
         $this->fs->mkdir($dir, 0o700);
 
-        $privateKeyFilename = $dir . DIRECTORY_SEPARATOR . self::PRIVATE_KEY_FILENAME;
+        $privateKeyFilename = $dir . DIRECTORY_SEPARATOR . $this->privateKeyFilename();
         $certificateFilename = $privateKeyFilename . '-cert.pub';
         $publicKeyFilename = $privateKeyFilename . '.pub';
         $tempPrivateKeyFilename = $privateKeyFilename . '_tmp';
@@ -156,7 +156,7 @@ class Certifier
     public function getExistingCertificate(): ?Certificate
     {
         $dir = $this->config->getSessionDir(true) . DIRECTORY_SEPARATOR . 'ssh';
-        $private = $dir . DIRECTORY_SEPARATOR . self::PRIVATE_KEY_FILENAME;
+        $private = $dir . DIRECTORY_SEPARATOR . $this->privateKeyFilename();
         $cert = $private . '-cert.pub';
 
         $exists = file_exists($private) && file_exists($cert);
@@ -244,6 +244,56 @@ class Certifier
     }
 
     /**
+     * Returns the key algorithm to use for the temporary certificate key pair.
+     */
+    private function keyAlgorithm(): string
+    {
+        return self::chooseKeyAlgorithm($this->config->getStr('ssh.cert_key_algorithm'), $this->isFipsEnabled());
+    }
+
+    /**
+     * Chooses the key algorithm based on the configured value and FIPS mode.
+     *
+     * The "auto" (or empty) value detects FIPS mode and uses rsa where ed25519
+     * is unavailable. Any explicit algorithm is used as-is, with no detection.
+     *
+     * @param string $configured The configured ssh.cert_key_algorithm value.
+     * @param bool $fipsEnabled Whether the host is in FIPS mode.
+     */
+    public static function chooseKeyAlgorithm(string $configured, bool $fipsEnabled): string
+    {
+        if ($configured === '' || $configured === 'auto') {
+            return $fipsEnabled ? 'rsa' : 'ed25519';
+        }
+        return $configured;
+    }
+
+    /**
+     * Returns whether the host kernel is in FIPS mode.
+     *
+     * Ed25519 is not available on FIPS-mode systems. This reads the standard
+     * Linux kernel flag; it returns false where the file does not exist.
+     */
+    private function isFipsEnabled(): bool
+    {
+        if (!is_readable(self::FIPS_FILE)) {
+            return false;
+        }
+        return trim((string) file_get_contents(self::FIPS_FILE)) === '1';
+    }
+
+    /**
+     * Returns the temporary private key filename (without its directory).
+     *
+     * The algorithm is included so that switching algorithms uses a distinct
+     * file rather than reusing a stale key.
+     */
+    private function privateKeyFilename(): string
+    {
+        return 'id_' . $this->keyAlgorithm();
+    }
+
+    /**
      * Generate an SSH key pair to request a new certificate.
      *
      * @param string $filename
@@ -255,7 +305,7 @@ class Certifier
 
         $args = [
             'ssh-keygen',
-            '-t', self::KEY_ALGORITHM,
+            '-t', $this->keyAlgorithm(),
             '-f', $filename,
             '-N', '', // No passphrase
             '-C', $this->config->getStr('application.slug') . '-temporary-cert', // Key comment

--- a/legacy/src/SshCert/Certifier.php
+++ b/legacy/src/SshCert/Certifier.php
@@ -340,13 +340,23 @@ class Certifier
     {
         $this->stdErr->writeln('Generating local key pair', OutputInterface::VERBOSITY_VERBOSE);
 
+        $algorithm = $this->keyAlgorithm();
         $args = [
             'ssh-keygen',
-            '-t', $this->keyAlgorithm(),
+            '-t', $algorithm,
             '-f', $filename,
             '-N', '', // No passphrase
             '-C', $this->config->getStr('application.slug') . '-temporary-cert', // Key comment
         ];
+
+        // Set an explicit RSA key size rather than relying on the host
+        // ssh-keygen default, which varies by OpenSSH version. 4096 bits is
+        // well above the FIPS minimum. Other algorithms have a fixed (ed25519)
+        // or independently valid (ecdsa) size.
+        if ($algorithm === 'rsa') {
+            $args[] = '-b';
+            $args[] = '4096';
+        }
 
         // The "y\n" input is passed to avoid an error or prompt if ssh-keygen
         // encounters existing keys. This seems to be necessary during race

--- a/legacy/src/SshCert/Certifier.php
+++ b/legacy/src/SshCert/Certifier.php
@@ -90,9 +90,14 @@ class Certifier
         $tempCertificateFilename = $tempPrivateKeyFilename . '-cert.pub';
         $tempPublicKeyFilename = $tempPrivateKeyFilename . '.pub';
 
-        // Remove the old certificate and key from the SSH agent.
+        // Remove old keys from the SSH agent. The filename depends on the key
+        // algorithm, so remove every certifier-managed key, not just the
+        // current one, to avoid leaving a stale identity loaded after an
+        // algorithm switch.
         if ($this->config->getBool('ssh.add_to_agent')) {
-            $this->shell->execute(['ssh-add', '-d', $privateKeyFilename], null, false, !$this->stdErr->isVeryVerbose());
+            foreach ($this->managedPrivateKeys($dir) as $keyFile) {
+                $this->shell->execute(['ssh-add', '-d', $keyFile], null, false, !$this->stdErr->isVeryVerbose());
+            }
         }
 
         $apiClient = $this->api->getClient();
@@ -299,6 +304,30 @@ class Certifier
     private function privateKeyFilename(): string
     {
         return 'id_' . $this->keyAlgorithm();
+    }
+
+    /**
+     * Lists the certifier-managed private key files in the session ssh dir.
+     *
+     * This matches the "id_<algorithm>" naming, excluding public keys,
+     * certificates and temporary files, so that keys for every algorithm can
+     * be removed from the SSH agent regardless of the current configuration.
+     *
+     * @param string $dir The session ssh directory.
+     *
+     * @return string[] Absolute private key filenames.
+     */
+    private function managedPrivateKeys(string $dir): array
+    {
+        $keys = [];
+        foreach (glob($dir . DIRECTORY_SEPARATOR . 'id_*') ?: [] as $file) {
+            $name = basename($file);
+            if (str_ends_with($name, '.pub') || str_contains($name, '_tmp')) {
+                continue;
+            }
+            $keys[] = $file;
+        }
+        return $keys;
     }
 
     /**

--- a/legacy/src/SshCert/Certifier.php
+++ b/legacy/src/SshCert/Certifier.php
@@ -259,11 +259,19 @@ class Certifier
      *
      * @param string $configured The configured ssh.cert_key_algorithm value.
      * @param bool $fipsEnabled Whether the host is in FIPS mode.
+     *
+     * @throws \InvalidArgumentException if an explicit value is not a plain key type token.
      */
     public static function chooseKeyAlgorithm(string $configured, bool $fipsEnabled): string
     {
+        $configured = trim($configured);
         if ($configured === '' || $configured === 'auto') {
             return $fipsEnabled ? 'rsa' : 'ed25519';
+        }
+        // The value is used both as an "ssh-keygen -t" type and to build the
+        // key filename, so reject anything that is not a plain token.
+        if (!preg_match('/^[a-z0-9-]+$/', $configured)) {
+            throw new \InvalidArgumentException(sprintf('Invalid ssh.cert_key_algorithm value: "%s"', $configured));
         }
         return $configured;
     }

--- a/legacy/tests/SshCert/CertifierTest.php
+++ b/legacy/tests/SshCert/CertifierTest.php
@@ -31,4 +31,30 @@ class CertifierTest extends TestCase
     {
         $this->assertSame($expected, Certifier::chooseKeyAlgorithm($configured, $fipsEnabled));
     }
+
+    public function testChooseKeyAlgorithmTrimsWhitespace(): void
+    {
+        $this->assertSame('rsa', Certifier::chooseKeyAlgorithm(' rsa ', false));
+        $this->assertSame('ed25519', Certifier::chooseKeyAlgorithm("auto\n", false));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidKeyAlgorithmProvider(): array
+    {
+        return [
+            'path traversal' => ['../../.ssh/id_rsa'],
+            'slash' => ['rsa/evil'],
+            'space inside' => ['rsa evil'],
+            'uppercase' => ['RSA'],
+        ];
+    }
+
+    #[DataProvider('invalidKeyAlgorithmProvider')]
+    public function testChooseKeyAlgorithmRejectsInvalidValues(string $configured): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Certifier::chooseKeyAlgorithm($configured, false);
+    }
 }

--- a/legacy/tests/SshCert/CertifierTest.php
+++ b/legacy/tests/SshCert/CertifierTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Platformsh\Cli\Tests\SshCert;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Platformsh\Cli\SshCert\Certifier;
+
+class CertifierTest extends TestCase
+{
+    /**
+     * @return array<string, array{string, bool, string}>
+     */
+    public static function keyAlgorithmProvider(): array
+    {
+        return [
+            'auto without FIPS' => ['auto', false, 'ed25519'],
+            'auto with FIPS' => ['auto', true, 'rsa'],
+            'empty without FIPS' => ['', false, 'ed25519'],
+            'empty with FIPS' => ['', true, 'rsa'],
+            'explicit rsa without FIPS' => ['rsa', false, 'rsa'],
+            'explicit rsa with FIPS' => ['rsa', true, 'rsa'],
+            'explicit ed25519 with FIPS' => ['ed25519', true, 'ed25519'],
+        ];
+    }
+
+    #[DataProvider('keyAlgorithmProvider')]
+    public function testChooseKeyAlgorithm(string $configured, bool $fipsEnabled, string $expected): void
+    {
+        $this->assertSame($expected, Certifier::chooseKeyAlgorithm($configured, $fipsEnabled));
+    }
+}


### PR DESCRIPTION
## Problem

The temporary key pair for an SSH certificate is always generated with `ssh-keygen -t ed25519`. Ed25519 is not in the FIPS-approved algorithm set, so key generation fails on FIPS-mode hosts, making `ssh-cert:load` and auto-loaded certificates unusable there.

## Change

Add an `ssh.cert_key_algorithm` config key, overridable via the `{PREFIX}SSH_CERT_KEY_ALGORITHM` env var.

- `auto` (the default): detect FIPS mode via `/proc/sys/crypto/fips_enabled` and use `rsa` where ed25519 is unavailable, `ed25519` otherwise.
- An explicit value (e.g. `rsa`, `ed25519`): used as-is, with no detection.

The temporary key filename is derived from the algorithm (`id_rsa`, `id_ed25519`) so switching does not reuse a stale key.

RSA works end to end with no further changes: the certificate parser already accepts `ssh-rsa-cert-v01@openssh.com` and the certifier API signs RSA public keys. ECDSA is out of scope (it would require an ECDSA branch in the certificate parser).

## Tests

- PHP unit test for the algorithm-resolution logic (`Certifier::chooseKeyAlgorithm`).
- Go integration test variant exercising the `rsa` path via `ssh-cert:info`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)