### PR TITLE
ci: publish to npm automatically on release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,12 @@ updates:
       go-deps:
         patterns:
           - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,49 @@ jobs:
         run: |
           rm -rf "${{ steps.signing-keys.outputs.key_dir }}"
 
+  npm:
+    runs-on: ubuntu-latest
+    needs: release
+    environment: production
+    permissions:
+      contents: read # gh release download
+      id-token: write # OIDC token for npm trusted publishing
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      # registry-url is deliberately unset: it would write an .npmrc authToken
+      # line bound to NODE_AUTH_TOKEN, and an empty token there shadows OIDC.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest # trusted publishing needs npm >= 11.5.1
+
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          mkdir -p dist
+          gh release download "$TAG" --repo upsun/cli --dir dist \
+            -p 'upsun_*_linux_amd64.tar.gz' \
+            -p 'upsun_*_linux_arm64.tar.gz' \
+            -p 'upsun_*_darwin_all.tar.gz' \
+            -p 'upsun_*_windows_amd64.zip'
+
+      - name: Build npm tarballs
+        run: make npm-pack
+
+      - name: Publish to npm
+        env:
+          NPM_TAG: ${{ needs.release.outputs.is_prerelease == 'true' && 'next' || 'latest' }}
+        run: make npm-publish
+
   docker:
     runs-on: ${{ matrix.runner }}
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,16 +171,19 @@ jobs:
         with:
           node-version: 22
 
-      - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest # trusted publishing needs npm >= 11.5.1
+      # Pinned for reproducible releases; bump intentionally. Trusted
+      # publishing needs npm >= 11.5.1, newer than the npm Node 22 bundles.
+      - name: Install npm with trusted-publishing support
+        run: npm install -g npm@11.16.0
 
       - name: Download release archives
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release.outputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
           mkdir -p dist
-          gh release download "$TAG" --repo upsun/cli --dir dist \
+          gh release download "$TAG" --repo "$REPO" --dir dist \
             -p 'upsun_*_linux_amd64.tar.gz' \
             -p 'upsun_*_linux_arm64.tar.gz' \
             -p 'upsun_*_darwin_all.tar.gz' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,15 +166,11 @@ jobs:
 
       # registry-url is deliberately unset: it would write an .npmrc authToken
       # line bound to NODE_AUTH_TOKEN, and an empty token there shadows OIDC.
+      # Node 24 bundles npm >= 11.5.1, which OIDC trusted publishing requires.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
-
-      # Pinned for reproducible releases; bump intentionally. Trusted
-      # publishing needs npm >= 11.5.1, newer than the npm Node 22 bundles.
-      - name: Install npm with trusted-publishing support
-        run: npm install -g npm@11.16.0
+          node-version: 24
 
       - name: Download release archives
         env:

--- a/npm/README.md
+++ b/npm/README.md
@@ -44,7 +44,21 @@ make npm-pack           # reads dist/, writes npm/dist/*.tgz
 The build script resolves the version from the GoReleaser archive
 filenames. Override with `VERSION=...` if you need to.
 
-## Publish
+## Automated publishing (CI)
+
+The `npm` job in `.github/workflows/release.yml` publishes automatically on
+every release tag: it downloads the release archives, runs `make npm-pack`,
+and runs `make npm-publish`. Prerelease tags publish under the `next`
+dist-tag; full releases under `latest`.
+
+Auth uses npm [trusted publishing](https://docs.npmjs.com/trusted-publishers)
+(OIDC) — no stored token, and provenance is generated automatically. This
+requires a one-time setup on npmjs.com: for each of the five packages, add a
+GitHub Actions trusted publisher pointing at repository `upsun/cli`, workflow
+`release.yml`, environment `production`. The job runs npm >= 11.5.1 (required
+for OIDC) and has `id-token: write`.
+
+## Manual publishing (fallback)
 
 ```sh
 make npm-publish              # publish all five packages in lockstep
@@ -56,9 +70,10 @@ The script publishes platform packages first, then the wrapper, so the
 registry is never in a state where the wrapper points at platform
 packages that don't yet exist.
 
-Auth is via the standard npm mechanism: `~/.npmrc` with a token, or the
-`actions/setup-node` action in CI populating one for you from
-`NODE_AUTH_TOKEN`. The `--access public` flag is set so first-time
+Run this in an interactive terminal: the npm account uses passkey-based MFA,
+so `npm publish` prompts for a one-time password and fails with `EOTP` when
+run non-interactively. Auth is via the standard npm mechanism: `~/.npmrc` with
+a token, or `npm login`. The `--access public` flag is set so first-time
 publishes of scoped packages do not get marked private.
 
 ## Versioning

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -64,10 +64,38 @@ done
 
 publish_one() {
   local tarball="$1"
+  # Re-derive name+version from the tarball so this stays self-contained.
+  local pkg_json name version
+  pkg_json=$(tar -xzOf "$tarball" package/package.json)
+  name=$(awk -F'"' '/"name":/ { print $4; exit }' <<<"$pkg_json")
+  version=$(awk -F'"' '/"version":/ { print $4; exit }' <<<"$pkg_json")
+
+  # Idempotent re-run: skip versions already on the registry. A publish can
+  # fail partway (e.g. a transient Sigstore transparency-log error during
+  # provenance signing) after some packages are already up; re-running then
+  # finishes the rest instead of erroring on "cannot publish over existing".
+  if npm view "${name}@${version}" version >/dev/null 2>&1; then
+    echo "  ${name}@${version} already published; skipping"
+    return 0
+  fi
+
   local args=(publish "$tarball" --access public --tag "${NPM_TAG}")
   if [ "${DRY_RUN}" = "1" ]; then args+=(--dry-run); fi
-  echo "  npm ${args[*]}"
-  npm "${args[@]}"
+
+  # Retry transient failures. npm provenance signing hits Sigstore's public
+  # Rekor log, which intermittently returns errors; each attempt regenerates a
+  # fresh signature, so a retry clears them.
+  local attempt
+  for attempt in 1 2 3; do
+    echo "  npm ${args[*]} (attempt ${attempt})"
+    if npm "${args[@]}"; then return 0; fi
+    if [ "${attempt}" -lt 3 ]; then
+      echo "  publish of ${name}@${version} failed; retrying in $((attempt * 10))s" >&2
+      sleep $((attempt * 10))
+    fi
+  done
+  echo "publish.sh: giving up on ${name}@${version} after 3 attempts" >&2
+  return 1
 }
 
 wait_visible() {

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -74,7 +74,9 @@ publish_one() {
   # fail partway (e.g. a transient Sigstore transparency-log error during
   # provenance signing) after some packages are already up; re-running then
   # finishes the rest instead of erroring on "cannot publish over existing".
-  if npm view "${name}@${version}" version >/dev/null 2>&1; then
+  # Skipped in dry-run so `npm publish --dry-run` still validates the tarball
+  # (and surfaces a version that was not bumped).
+  if [ "${DRY_RUN}" != "1" ] && npm view "${name}@${version}" version >/dev/null 2>&1; then
     echo "  ${name}@${version} already published; skipping"
     return 0
   fi
@@ -84,11 +86,21 @@ publish_one() {
 
   # Retry transient failures. npm provenance signing hits Sigstore's public
   # Rekor log, which intermittently returns errors; each attempt regenerates a
-  # fresh signature, so a retry clears them.
-  local attempt
+  # fresh signature, so a retry clears them. A publish-conflict is not
+  # transient: the version is already there (e.g. published by a prior attempt
+  # that `npm view` had not yet caught up to), so treat it as success rather
+  # than retrying to failure.
+  local attempt out rc
   for attempt in 1 2 3; do
     echo "  npm ${args[*]} (attempt ${attempt})"
-    if npm "${args[@]}"; then return 0; fi
+    # Capture inside `if` so `set -e` does not abort on a failed attempt.
+    if out=$(npm "${args[@]}" 2>&1); then rc=0; else rc=$?; fi
+    printf '%s\n' "$out"
+    if [ "$rc" -eq 0 ]; then return 0; fi
+    if printf '%s' "$out" | grep -qiE 'EPUBLISHCONFLICT|cannot publish over'; then
+      echo "  ${name}@${version} already published; treating as success"
+      return 0
+    fi
     if [ "${attempt}" -lt 3 ]; then
       echo "  publish of ${name}@${version} failed; retrying in $((attempt * 10))s" >&2
       sleep $((attempt * 10))

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -6,9 +6,10 @@
 #   NPM_TAG      dist-tag, e.g. "latest" or "next". Default: "latest"
 #   DRY_RUN      1 to run npm publish --dry-run. Default: 0
 #
-# Auth: requires ~/.npmrc to have a working //registry.npmjs.org/:_authToken,
-# or NODE_AUTH_TOKEN set with a registry-url-configured ~/.npmrc (the
-# setup-node action handles this in CI).
+# Auth: in CI this runs under npm OIDC trusted publishing (no token; npm
+# exchanges a GitHub Actions OIDC token automatically). Run by hand, it uses
+# the standard npm mechanism: ~/.npmrc with a //registry.npmjs.org/:_authToken,
+# or `npm login`. Note `npm login` needs an interactive terminal (passkey MFA).
 #
 # Order: platform packages first, then wait for them to become visible
 # in the public registry, then publish the wrapper. The wait matters:


### PR DESCRIPTION
Publishes the CLI to npm automatically on every release tag, replacing the manual `make npm-publish` step. This keeps npm in lockstep with GitHub releases (npm `latest` had drifted behind), and removes the manual publish, which has to run in an interactive terminal because the npm account uses passkey-based MFA.

## What it does

Adds an `npm` job to `release.yml` (`needs: release`) that:
- downloads the release archives,
- runs `make npm-pack`,
- runs `make npm-publish`.

Prerelease tags publish under the `next` dist-tag; full releases under `latest`. The job is independent of the `docker` jobs, so an npm failure won't block the rest of a release and the job can be re-run on its own.

## Auth

Uses npm OIDC trusted publishing: no stored token, and provenance is generated automatically. Requirements:
- npm >= 11.5.1 and `id-token: write` (the job runs on Node 24, whose bundled npm satisfies this).
- a one-time trusted-publisher setup on npmjs.com for each of the five packages (`upsun`, `@upsun/cli-linux-x64`, `@upsun/cli-linux-arm64`, `@upsun/cli-darwin`, `@upsun/cli-win32-x64`), pointing at this repo, workflow `release.yml`, environment `production` — already configured.

`registry-url` is deliberately left unset on `setup-node`: it would write an `.npmrc` authToken line that shadows OIDC.

## Also in this PR

- **Node 24, no explicit npm install:** the job uses Node 24, whose bundled npm is >= 11.5.1, so there's no separate `npm install -g` step to pin and maintain.
- **Dependabot for GitHub Actions:** adds the `github-actions` ecosystem so action `uses:` versions stay current, grouped weekly like the existing ecosystems.
- `npm/README.md` documents the automated flow and keeps the manual flow as a fallback.

## Testing

The publish path was exercised end-to-end with throwaway prerelease tags (published under `next`, with provenance; `latest` untouched). These test artifacts will be cleaned up before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)