### PR TITLE
chore(legacy): upgrade PHPStan to 2.x

### DIFF
--- a/legacy/composer.json
+++ b/legacy/composer.json
@@ -49,7 +49,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11",
-        "rector/rector": "^1.2",
+        "phpstan/phpstan": "^2.1",
+        "rector/rector": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.92"
     },
     "authors": [

--- a/legacy/composer.lock
+++ b/legacy/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22eb7daddf22918459b152dbe3f918d7",
+    "content-hash": "04af23f800352c7e7ed4a9744cfb2ccb",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -3797,15 +3797,15 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.33",
+            "version": "2.2.2",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
-                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -3823,6 +3823,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -3846,7 +3857,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-28T20:30:03+00:00"
+            "time": "2026-06-05T09:00:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4883,21 +4894,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "1.2.10",
+            "version": "2.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "40f9cf38c05296bd32f444121336a521a293fa61"
+                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40f9cf38c05296bd32f444121336a521a293fa61",
-                "reference": "40f9cf38c05296bd32f444121336a521a293fa61",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.12.5"
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.56"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -4922,6 +4933,7 @@
                 "MIT"
             ],
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
             "keywords": [
                 "automation",
                 "dev",
@@ -4930,7 +4942,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/1.2.10"
+                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
             },
             "funding": [
                 {
@@ -4938,7 +4950,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-08T13:59:10+00:00"
+            "time": "2026-05-26T21:03:22+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -6351,5 +6363,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/legacy/phpstan-baseline.neon
+++ b/legacy/phpstan-baseline.neon
@@ -1,846 +1,1363 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$commandName of method Symfony\\\\Component\\\\Console\\\\Application\\:\\:setDefaultCommand\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$commandName of method Symfony\\Component\\Console\\Application\:\:setDefaultCommand\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Application.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Platformsh\\\\Cli\\\\Service\\\\Config\\:\\:isCommandEnabled\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$name of method Platformsh\\Cli\\Service\\Config\:\:isCommandEnabled\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Application.php
 
 		-
-			message: "#^Call to an undefined method Platformsh\\\\Client\\\\Connection\\\\ConnectorInterface\\:\\:getOAuth2Provider\\(\\)\\.$#"
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\ApiResourceBase\:\:\$created_at\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Command/Activity/ActivityCancelCommand.php
+
+		-
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\ApiResourceBase\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 5
+			path: src/Command/Activity/ActivityCancelCommand.php
+
+		-
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\ApiResourceBase\:\:\$state\.$#'
+			identifier: property.notFound
+			count: 2
+			path: src/Command/Activity/ActivityCancelCommand.php
+
+		-
+			message: '#^Call to an undefined method Platformsh\\Client\\Model\\ApiResourceBase\:\:cancel\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Command/Activity/ActivityCancelCommand.php
+
+		-
+			message: '#^Parameter \#1 \$activity of static method Platformsh\\Cli\\Service\\ActivityMonitor\:\:getFormattedDescription\(\) expects Platformsh\\Client\\Model\\Activity, Platformsh\\Client\\Model\\ApiResourceBase given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Command/Activity/ActivityCancelCommand.php
+
+		-
+			message: '#^Parameter \#1 \$values of method Symfony\\Component\\Console\\Completion\\CompletionSuggestions\:\:suggestValues\(\) expects list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>, array\<string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/Activity/ActivityCommandBase.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/App/AppConfigGetCommand.php
+
+		-
+			message: '#^Call to an undefined method Platformsh\\Client\\Connection\\ConnectorInterface\:\:getOAuth2Provider\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Auth/ApiTokenLoginCommand.php
 
 		-
-			message: "#^Call to an undefined method Platformsh\\\\Client\\\\Connection\\\\ConnectorInterface\\:\\:saveToken\\(\\)\\.$#"
+			message: '#^Call to an undefined method Platformsh\\Client\\Connection\\ConnectorInterface\:\:saveToken\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Auth/ApiTokenLoginCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:post\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:post\(\)\.$#'
+			identifier: method.notFound
 			count: 3
 			path: src/Command/Auth/VerifyPhoneNumberCommand.php
 
 		-
-			message: "#^Offset 'triggers' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Command\\Autoscaling\\AutoscalingSettingsSetCommand\:\:handleScalingSettings\(\) never assigns null to &\$cooldown so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: src/Command/Autoscaling/AutoscalingSettingsSetCommand.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Command\\Autoscaling\\AutoscalingSettingsSetCommand\:\:handleScalingSettings\(\) never assigns null to &\$duration so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: src/Command/Autoscaling/AutoscalingSettingsSetCommand.php
+
+		-
+			message: '#^Offset ''triggers'' might not exist on array\<string, mixed\>\|null\.$#'
+			identifier: offsetAccess.notFound
 			count: 2
 			path: src/Command/Autoscaling/AutoscalingSettingsSetCommand.php
 
 		-
-			message: "#^Access to an undefined property Platformsh\\\\Client\\\\Model\\\\Backup\\:\\:\\$safe\\.$#"
+			message: '#^Strict comparison using \=\=\= between null and null will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: src/Command/Autoscaling/AutoscalingSettingsSetCommand.php
+
+		-
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\Backup\:\:\$safe\.$#'
+			identifier: property.notFound
 			count: 2
 			path: src/Command/Backup/BackupListCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:delete\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:delete\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/BlueGreen/BlueGreenConcludeCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/BlueGreen/BlueGreenConcludeCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/BlueGreen/BlueGreenDeployCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:patch\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:patch\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/BlueGreen/BlueGreenDeployCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/BlueGreen/BlueGreenEnableCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:post\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:post\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/BlueGreen/BlueGreenEnableCommand.php
 
 		-
-			message: "#^While loop condition is always true\\.$#"
+			message: '#^While loop condition is always true\.$#'
+			identifier: while.alwaysTrue
 			count: 1
 			path: src/Command/BotCommand.php
 
 		-
-			message: "#^Cannot call method getStr\\(\\) on Platformsh\\\\Cli\\\\Service\\\\Config\\|null\\.$#"
+			message: '#^Cannot call method getStr\(\) on Platformsh\\Cli\\Service\\Config\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: src/Command/CommandBase.php
 
 		-
-			message: "#^Cannot call method isCommandEnabled\\(\\) on Platformsh\\\\Cli\\\\Service\\\\Config\\|null\\.$#"
+			message: '#^Cannot call method isCommandEnabled\(\) on Platformsh\\Cli\\Service\\Config\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/CommandBase.php
 
 		-
-			message: "#^Cannot call method isCommandHidden\\(\\) on Platformsh\\\\Cli\\\\Service\\\\Config\\|null\\.$#"
+			message: '#^Cannot call method isCommandHidden\(\) on Platformsh\\Cli\\Service\\Config\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/CommandBase.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Command\\\\CommandBase\\:\\:getPreferredName\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Command\\CommandBase\:\:getPreferredName\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Command/CommandBase.php
 
 		-
-			message: "#^Parameter \\#3 \\$name of static method Platformsh\\\\Cli\\\\Model\\\\EnvironmentDomain\\:\\:add\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#2 \$replace of function str_replace expects array\<string\>\|string, array\<int, string\|null\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/CommandBase.php
+
+		-
+			message: '#^Parameter \#3 \$name of static method Platformsh\\Cli\\Model\\EnvironmentDomain\:\:add\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Domain/DomainAddCommand.php
 
 		-
-			message: "#^Cannot call method getLink\\(\\) on Platformsh\\\\Client\\\\Model\\\\Environment\\|null\\.$#"
+			message: '#^Parameter \#1 \$domain of method Platformsh\\Cli\\Command\\Domain\\DomainCommandBase\:\:validDomain\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/Domain/DomainCommandBase.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Command/Domain/DomainCommandBase.php
+
+		-
+			message: '#^Cannot call method getLink\(\) on Platformsh\\Client\\Model\\Environment\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Domain/DomainGetCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$environment of static method Platformsh\\\\Cli\\\\Model\\\\EnvironmentDomain\\:\\:getList\\(\\) expects Platformsh\\\\Client\\\\Model\\\\Environment, Platformsh\\\\Client\\\\Model\\\\Environment\\|null given\\.$#"
+			message: '#^Parameter \#1 \$environment of static method Platformsh\\Cli\\Model\\EnvironmentDomain\:\:getList\(\) expects Platformsh\\Client\\Model\\Environment, Platformsh\\Client\\Model\\Environment\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Domain/DomainGetCommand.php
 
 		-
-			message: "#^Cannot call method getLink\\(\\) on Platformsh\\\\Client\\\\Model\\\\Environment\\|null\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: src/Command/Domain/DomainListCommand.php
+
+		-
+			message: '#^Cannot call method getLink\(\) on Platformsh\\Client\\Model\\Environment\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Domain/DomainUpdateCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$id of static method Platformsh\\\\Client\\\\Model\\\\ApiResourceBase\\:\\:get\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$id of static method Platformsh\\Client\\Model\\ApiResourceBase\:\:get\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Domain/DomainUpdateCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Platformsh\\\\Client\\\\Model\\\\Project\\:\\:getDomain\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$name of method Platformsh\\Client\\Model\\Project\:\:getDomain\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Domain/DomainUpdateCommand.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Command\\\\Environment\\\\EnvironmentPushCommand\\:\\:execute\\(\\) should return int but returns int\\|null\\.$#"
+			message: '#^Strict comparison using \!\=\= between \(int\|string\) and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: src/Command/Environment/EnvironmentCheckoutCommand.php
+
+		-
+			message: '#^Call to preg_quote\(\) is missing delimiter / to be effective\.$#'
+			identifier: argument.invalidPregQuote
+			count: 1
+			path: src/Command/Environment/EnvironmentDrushCommand.php
+
+		-
+			message: '#^Parameter \#1 \$environments of method Platformsh\\Cli\\Command\\Environment\\EnvironmentListCommand\:\:buildEnvironmentTree\(\) expects array\<Platformsh\\Client\\Model\\Environment\>, array\<Platformsh\\Client\\Model\\ApiResourceBase\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/Environment/EnvironmentListCommand.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Command\\Environment\\EnvironmentPushCommand\:\:execute\(\) should return int but returns int\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Command/Environment/EnvironmentPushCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$id of method Platformsh\\\\Cli\\\\Service\\\\Api\\:\\:getEnvironment\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$id of method Platformsh\\Cli\\Service\\Api\:\:getEnvironment\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Environment/EnvironmentSynchronizeCommand.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Command\\\\Environment\\\\EnvironmentXdebugCommand\\:\\:execute\\(\\) should return int but returns int\\|null\\.$#"
+			message: '#^Parameter \#1 \$string of function base64_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/Environment/EnvironmentUrlCommand.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Command\\Environment\\EnvironmentXdebugCommand\:\:execute\(\) should return int but returns int\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Command/Environment/EnvironmentXdebugCommand.php
 
 		-
-			message: "#^Cannot call method find\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
+			message: '#^Cannot call method find\(\) on Symfony\\Component\\Console\\Application\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: src/Command/HelpCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:post\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:post\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Integration/IntegrationCommandBase.php
 
 		-
-			message: "#^Cannot call method getProject\\(\\) on Platformsh\\\\Cli\\\\Selector\\\\Selection\\|null\\.$#"
+			message: '#^Cannot call method getProject\(\) on Platformsh\\Cli\\Selector\\Selection\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Integration/IntegrationCommandBase.php
 
 		-
-			message: "#^Cannot call method hasProject\\(\\) on Platformsh\\\\Cli\\\\Selector\\\\Selection\\|null\\.$#"
+			message: '#^Cannot call method hasProject\(\) on Platformsh\\Cli\\Selector\\Selection\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: src/Command/Integration/IntegrationCommandBase.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Command\\\\Integration\\\\IntegrationCommandBase\\:\\:selectedProjectIntegrationCapabilities\\(\\) should return array\\{enabled\\: bool, config\\?\\: array\\<string, array\\{enabled\\: bool\\}\\>\\} but returns array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Command\\Integration\\IntegrationCommandBase\:\:selectedProjectIntegrationCapabilities\(\) should return array\{enabled\: bool, config\?\: array\<string, array\{enabled\: bool\}\>\} but returns array\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Command/Integration/IntegrationCommandBase.php
 
 		-
-			message: "#^Parameter \\#1 \\$app of method Platformsh\\\\Client\\\\Model\\\\Environment\\:\\:getSshUrl\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$app of method Platformsh\\Client\\Model\\Environment\:\:getSshUrl\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Local/LocalDrushAliasesCommand.php
 
 		-
-			message: "#^Cannot call method set\\(\\) on Platformsh\\\\ConsoleForm\\\\Field\\\\Field\\|false\\.$#"
+			message: '#^Method Platformsh\\Cli\\Command\\MultiCommand\:\:getAllProjectsBasicInfo\(\) should return array\<Platformsh\\Client\\Model\\BasicProjectInfo\> but returns array\<object\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Command/MultiCommand.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: src/Command/Organization/Billing/OrganizationProfileCommand.php
+
+		-
+			message: '#^Cannot call method set\(\) on Platformsh\\ConsoleForm\\Field\\Field\|false\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Organization/OrganizationCreateCommand.php
 
 		-
-			message: "#^Cannot access property \\$email on Platformsh\\\\Client\\\\Model\\\\Ref\\\\UserRef\\|null\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: src/Command/Organization/OrganizationInfoCommand.php
+
+		-
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\ApiResourceBase\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Command/Organization/OrganizationListCommand.php
+
+		-
+			message: '#^Call to an undefined method Platformsh\\Client\\Model\\ApiResourceBase\:\:getOwnerInfo\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Command/Organization/OrganizationListCommand.php
+
+		-
+			message: '#^Cannot access property \$email on Platformsh\\Client\\Model\\Ref\\UserRef\|null\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/Command/Organization/User/OrganizationUserProjectsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$userRef of method Platformsh\\\\Cli\\\\Service\\\\Api\\:\\:getUserRefLabel\\(\\) expects Platformsh\\\\Client\\\\Model\\\\Ref\\\\UserRef, Platformsh\\\\Client\\\\Model\\\\Ref\\\\UserRef\\|null given\\.$#"
+			message: '#^Parameter \#1 \$userRef of method Platformsh\\Cli\\Service\\Api\:\:getUserRefLabel\(\) expects Platformsh\\Client\\Model\\Ref\\UserRef, Platformsh\\Client\\Model\\Ref\\UserRef\|null given\.$#'
+			identifier: argument.type
 			count: 4
 			path: src/Command/Organization/User/OrganizationUserProjectsCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Project/ProjectCreateCommand.php
 
 		-
-			message: "#^Cannot call method has\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
+			message: '#^Cannot call method has\(\) on Symfony\\Component\\Console\\Application\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Project/ProjectGetCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$rows of method Platformsh\\\\Cli\\\\Service\\\\Table\\:\\:render\\(\\) expects array\\<array\\<int\\|string, float\\|int\\|string\\|Symfony\\\\Component\\\\Console\\\\Helper\\\\TableCell\\>\\|Symfony\\\\Component\\\\Console\\\\Helper\\\\TableSeparator\\>, array\\<int, array\\<string, Platformsh\\\\Cli\\\\Console\\\\AdaptiveTableCell\\|string\\|null\\>\\> given\\.$#"
+			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(object\)\: mixed\)\|null, Closure\(Platformsh\\Client\\Model\\BasicProjectInfo\)\: string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/Project/ProjectListCommand.php
+
+		-
+			message: '#^Parameter \#1 \$rows of method Platformsh\\Cli\\Service\\Table\:\:render\(\) expects array\<array\<int\|string, float\|int\|string\|Symfony\\Component\\Console\\Helper\\TableCell\>\|Symfony\\Component\\Console\\Helper\\TableSeparator\>, list\<array\<string, Platformsh\\Cli\\Console\\AdaptiveTableCell\|string\|null\>\> given\.$#'
+			identifier: argument.type
 			count: 2
 			path: src/Command/Project/ProjectListCommand.php
 
 		-
-			message: "#^Trying to invoke \\(callable\\(\\)\\: mixed\\)\\|null but it might not be a callable\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: src/Command/Resources/ResourcesSetCommand.php
 
 		-
-			message: "#^Access to an undefined property Platformsh\\\\Client\\\\Model\\\\Deployment\\\\Service\\|Platformsh\\\\Client\\\\Model\\\\Deployment\\\\WebApp\\|Platformsh\\\\Client\\\\Model\\\\Deployment\\\\Worker\\:\\:\\$container_profile\\.$#"
+			message: '#^Strict comparison using \=\=\= between mixed and \*NEVER\* will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Command/Resources/ResourcesSetCommand.php
+
+		-
+			message: '#^Trying to invoke \(callable\(\)\: mixed\)\|null but it might not be a callable\.$#'
+			identifier: callable.nonCallable
+			count: 1
+			path: src/Command/Resources/ResourcesSetCommand.php
+
+		-
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\Deployment\\Service\|Platformsh\\Client\\Model\\Deployment\\WebApp\|Platformsh\\Client\\Model\\Deployment\\Worker\:\:\$container_profile\.$#'
+			identifier: property.notFound
 			count: 3
 			path: src/Command/Resources/ResourcesSizeListCommand.php
 
 		-
-			message: "#^Parameter \\#2 \\$service of method Platformsh\\\\Client\\\\Model\\\\Deployment\\\\EnvironmentDeployment\\:\\:execRuntimeOperation\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$string of function base64_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/Route/RouteGetCommand.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/Route/RouteListCommand.php
+
+		-
+			message: '#^Parameter \#2 \$service of method Platformsh\\Client\\Model\\Deployment\\EnvironmentDeployment\:\:execRuntimeOperation\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/RuntimeOperation/RunCommand.php
 
 		-
-			message: "#^Parameter \\#2 \\$content of method Symfony\\\\Component\\\\Filesystem\\\\Filesystem\\:\\:dumpFile\\(\\) expects resource\\|string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$path of function basename expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Self/SelfInstallCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:writeln\\(\\) expects iterable\\|string, string\\|null given\\.$#"
+			message: '#^Parameter \#2 \$content of method Symfony\\Component\\Filesystem\\Filesystem\:\:dumpFile\(\) expects resource\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/Self/SelfInstallCommand.php
+
+		-
+			message: '#^Parameter \#1 \$messages of method Symfony\\Component\\Console\\Output\\OutputInterface\:\:writeln\(\) expects iterable\|string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Self/SelfReleaseCommand.php
 
 		-
-			message: "#^Parameter \\#2 \\$pid of method Platformsh\\\\Cli\\\\Command\\\\Server\\\\ServerCommandBase\\:\\:writeServerInfo\\(\\) expects int, int\\|null given\\.$#"
+			message: '#^Parameter \#2 \$pid of method Platformsh\\Cli\\Command\\Server\\ServerCommandBase\:\:writeServerInfo\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Server/ServerRunCommand.php
 
 		-
-			message: "#^Parameter \\#2 \\$pid of method Platformsh\\\\Cli\\\\Command\\\\Server\\\\ServerCommandBase\\:\\:writeServerInfo\\(\\) expects int, int\\|null given\\.$#"
+			message: '#^Parameter \#2 \$pid of method Platformsh\\Cli\\Command\\Server\\ServerCommandBase\:\:writeServerInfo\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/Server/ServerStartCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$items of method Platformsh\\\\Cli\\\\Service\\\\QuestionHelper\\:\\:choose\\(\\) expects array\\<string, string\\>, array\\<int\\|string, string\\> given\\.$#"
+			message: '#^Strict comparison using \!\=\= between string and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: src/Command/Service/ServiceListCommand.php
+
+		-
+			message: '#^Parameter \#1 \$items of method Platformsh\\Cli\\Service\\QuestionHelper\:\:choose\(\) expects array\<string, string\>, array\<int, string\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/SshKey/SshKeyDeleteCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:post\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:post\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Team/Project/TeamProjectAddCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:delete\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:delete\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Team/Project/TeamProjectDeleteCommand.php
 
 		-
-			message: "#^Cannot call method has\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
+			message: '#^Cannot call method has\(\) on Symfony\\Component\\Console\\Application\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: src/Command/Team/TeamCommandBase.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Team/TeamListCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:post\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:post\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Team/User/TeamUserAddCommand.php
 
 		-
-			message: "#^Cannot call method has\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
+			message: '#^Cannot call method has\(\) on Symfony\\Component\\Console\\Application\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Team/User/TeamUserAddCommand.php
 
 		-
-			message: "#^Cannot access property \\$type on Platformsh\\\\Client\\\\Model\\\\Environment\\|null\\.$#"
+			message: '#^Cannot access property \$type on Platformsh\\Client\\Model\\Environment\|null\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/Command/User/UserGetCommand.php
 
 		-
-			message: "#^Cannot call method getUser\\(\\) on Platformsh\\\\Client\\\\Model\\\\Environment\\|null\\.$#"
+			message: '#^Cannot call method getUser\(\) on Platformsh\\Client\\Model\\Environment\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/User/UserGetCommand.php
 
 		-
-			message: "#^Cannot access property \\$id on Platformsh\\\\Client\\\\Model\\\\Environment\\|null\\.$#"
+			message: '#^Cannot access property \$id on Platformsh\\Client\\Model\\Environment\|null\.$#'
+			identifier: property.nonObject
 			count: 2
 			path: src/Command/Variable/VariableCreateCommand.php
 
 		-
-			message: "#^Cannot call method getFields\\(\\) on Platformsh\\\\ConsoleForm\\\\Form\\|null\\.$#"
+			message: '#^Cannot call method getFields\(\) on Platformsh\\ConsoleForm\\Form\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Variable/VariableCreateCommand.php
 
 		-
-			message: "#^Cannot call method getLink\\(\\) on Platformsh\\\\Client\\\\Model\\\\Environment\\|null\\.$#"
+			message: '#^Cannot call method getLink\(\) on Platformsh\\Client\\Model\\Environment\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Variable/VariableCreateCommand.php
 
 		-
-			message: "#^Cannot call method getVariable\\(\\) on Platformsh\\\\Client\\\\Model\\\\Environment\\|null\\.$#"
+			message: '#^Cannot call method getVariable\(\) on Platformsh\\Client\\Model\\Environment\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Variable/VariableCreateCommand.php
 
 		-
-			message: "#^Cannot call method resolveOptions\\(\\) on Platformsh\\\\ConsoleForm\\\\Form\\|null\\.$#"
+			message: '#^Cannot call method resolveOptions\(\) on Platformsh\\ConsoleForm\\Form\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Variable/VariableCreateCommand.php
 
 		-
-			message: "#^Dead catch \\- Platformsh\\\\ConsoleForm\\\\Exception\\\\ConditionalFieldException is never thrown in the try block\\.$#"
+			message: '#^Dead catch \- Platformsh\\ConsoleForm\\Exception\\ConditionalFieldException is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
 			count: 1
 			path: src/Command/Variable/VariableCreateCommand.php
 
 		-
-			message: "#^Cannot call method getFields\\(\\) on Platformsh\\\\ConsoleForm\\\\Form\\|null\\.$#"
+			message: '#^Cannot call method getFields\(\) on Platformsh\\ConsoleForm\\Form\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Command/Variable/VariableUpdateCommand.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Command/Version/VersionListCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:writeln\\(\\) expects iterable\\|string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$messages of method Symfony\\Component\\Console\\Output\\OutputInterface\:\:writeln\(\) expects iterable\|string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Command/WelcomeCommand.php
 
 		-
-			message: "#^While loop condition is always true\\.$#"
+			message: '#^While loop condition is always true\.$#'
+			identifier: while.alwaysTrue
 			count: 1
 			path: src/Command/WinkyCommand.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\AdaptiveTable\\:\\:wrapCell\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\AdaptiveTable\:\:wrapCell\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Console/AdaptiveTable.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\AdaptiveTable\\:\\:wrapWithDecoration\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\AdaptiveTable\:\:wrapWithDecoration\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Console/AdaptiveTable.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:describeApplication\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:describeApplication\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:describeCommand\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:describeCommand\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:describeInputArgument\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:describeInputArgument\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:describeInputDefinition\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:describeInputDefinition\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:describeInputOption\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:describeInputOption\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:getCommandData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:getCommandData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:getInputArgumentData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:getInputArgumentData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:getInputDefinitionData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:getInputDefinitionData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:getInputOptionData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:getInputOptionData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:writeData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:writeData\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomJsonDescriptor\\:\\:writeData\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomJsonDescriptor\:\:writeData\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Parameter \\#1 \\$content of method Symfony\\\\Component\\\\Console\\\\Descriptor\\\\Descriptor\\:\\:write\\(\\) expects string, string\\|false given\\.$#"
+			message: '#^Parameter \#1 \$content of method Symfony\\Component\\Console\\Descriptor\\Descriptor\:\:write\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Console/CustomJsonDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomMarkdownDescriptor\\:\\:describeApplication\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomMarkdownDescriptor\:\:describeApplication\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomMarkdownDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomMarkdownDescriptor\\:\\:describeCommand\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomMarkdownDescriptor\:\:describeCommand\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomMarkdownDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomMarkdownDescriptor\\:\\:describeInputArgument\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomMarkdownDescriptor\:\:describeInputArgument\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomMarkdownDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomMarkdownDescriptor\\:\\:describeInputOption\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomMarkdownDescriptor\:\:describeInputOption\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomMarkdownDescriptor.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Console/CustomMarkdownDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomTextDescriptor\\:\\:describeApplication\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomTextDescriptor\:\:describeApplication\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomTextDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomTextDescriptor\\:\\:describeCommand\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomTextDescriptor\:\:describeCommand\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomTextDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomTextDescriptor\\:\\:describeInputOption\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomTextDescriptor\:\:describeInputOption\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomTextDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomTextDescriptor\\:\\:formatAliases\\(\\) has parameter \\$aliases with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomTextDescriptor\:\:formatAliases\(\) has parameter \$aliases with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomTextDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomTextDescriptor\\:\\:getColumnWidth\\(\\) has parameter \\$commands with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomTextDescriptor\:\:getColumnWidth\(\) has parameter \$commands with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomTextDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\CustomTextDescriptor\\:\\:writeText\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\CustomTextDescriptor\:\:writeText\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Console/CustomTextDescriptor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Console\\\\ProcessManager\\:\\:startProcess\\(\\) should return int but returns int\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Console\\ProcessManager\:\:startProcess\(\) should return int but returns int\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Console/ProcessManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$exitCode of method Platformsh\\\\Cli\\\\Console\\\\ProcessManager\\:\\:getSignal\\(\\) expects int, int\\|null given\\.$#"
+			message: '#^Parameter \#1 \$exitCode of method Platformsh\\Cli\\Console\\ProcessManager\:\:getSignal\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Console/ProcessManager.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\CredentialHelper\\\\SessionStorage\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\CredentialHelper\\SessionStorage\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/CredentialHelper/SessionStorage.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\CredentialHelper\\\\SessionStorage\\:\\:save\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Platformsh\\Cli\\CredentialHelper\\SessionStorage\:\:save\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/CredentialHelper/SessionStorage.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Exception\\\\ConnectionFailedException\\:\\:\\$code has no type specified\\.$#"
+			message: '#^Property Platformsh\\Cli\\Exception\\ConnectionFailedException\:\:\$code has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/Exception/ConnectionFailedException.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Exception\\\\ConnectionFailedException\\:\\:\\$message has no type specified\\.$#"
-			count: 1
-			path: src/Exception/ConnectionFailedException.php
-
-		-
-			message: "#^Method Platformsh\\\\Cli\\\\Exception\\\\DependencyMissingException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
+			message: '#^Method Platformsh\\Cli\\Exception\\DependencyMissingException\:\:__construct\(\) has parameter \$message with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Exception/DependencyMissingException.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Exception\\\\InvalidConfigException\\:\\:\\$code has no type specified\\.$#"
+			message: '#^Property Platformsh\\Cli\\Exception\\InvalidConfigException\:\:\$code has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/Exception/InvalidConfigException.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Exception\\\\LoginRequiredException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
+			message: '#^Method Platformsh\\Cli\\Exception\\LoginRequiredException\:\:__construct\(\) has parameter \$message with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Exception/LoginRequiredException.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Exception\\\\LoginRequiredException\\:\\:__construct\\(\\) has parameter \\$previous with no type specified\\.$#"
+			message: '#^Method Platformsh\\Cli\\Exception\\LoginRequiredException\:\:__construct\(\) has parameter \$previous with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Exception/LoginRequiredException.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Exception\\\\LoginRequiredException\\:\\:\\$code has no type specified\\.$#"
+			message: '#^Property Platformsh\\Cli\\Exception\\LoginRequiredException\:\:\$code has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/Exception/LoginRequiredException.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Exception\\\\LoginRequiredException\\:\\:\\$message has no type specified\\.$#"
-			count: 1
-			path: src/Exception/LoginRequiredException.php
-
-		-
-			message: "#^Property Platformsh\\\\Cli\\\\Exception\\\\PermissionDeniedException\\:\\:\\$code has no type specified\\.$#"
+			message: '#^Property Platformsh\\Cli\\Exception\\PermissionDeniedException\:\:\$code has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/Exception/PermissionDeniedException.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Exception\\\\PermissionDeniedException\\:\\:\\$message has no type specified\\.$#"
-			count: 1
-			path: src/Exception/PermissionDeniedException.php
-
-		-
-			message: "#^Property Platformsh\\\\Cli\\\\Exception\\\\ProjectNotFoundException\\:\\:\\$code has no type specified\\.$#"
+			message: '#^Property Platformsh\\Cli\\Exception\\ProjectNotFoundException\:\:\$code has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/Exception/ProjectNotFoundException.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Exception\\\\RootNotFoundException\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#"
+			message: '#^Method Platformsh\\Cli\\Exception\\RootNotFoundException\:\:__construct\(\) has parameter \$code with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Exception/RootNotFoundException.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Exception\\\\RootNotFoundException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
+			message: '#^Method Platformsh\\Cli\\Exception\\RootNotFoundException\:\:__construct\(\) has parameter \$message with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Exception/RootNotFoundException.php
 
 		-
-			message: "#^Cannot call method getName\\(\\) on Platformsh\\\\Cli\\\\Local\\\\LocalApplication\\|null\\.$#"
+			message: '#^Cannot call method getName\(\) on Platformsh\\Cli\\Local\\LocalApplication\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Cannot call method getSharedFileMounts\\(\\) on Platformsh\\\\Cli\\\\Local\\\\LocalApplication\\|null\\.$#"
+			message: '#^Cannot call method getSharedFileMounts\(\) on Platformsh\\Cli\\Local\\LocalApplication\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Cannot call method getSourceDir\\(\\) on Platformsh\\\\Cli\\\\Local\\\\LocalApplication\\|null\\.$#"
+			message: '#^Cannot call method getSourceDir\(\) on Platformsh\\Cli\\Local\\LocalApplication\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Cannot call method getStr\\(\\) on Platformsh\\\\Cli\\\\Service\\\\Config\\|null\\.$#"
+			message: '#^Cannot call method getStr\(\) on Platformsh\\Cli\\Service\\Config\|null\.$#'
+			identifier: method.nonObject
 			count: 3
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Cannot call method isSingle\\(\\) on Platformsh\\\\Cli\\\\Local\\\\LocalApplication\\|null\\.$#"
+			message: '#^Cannot call method isSingle\(\) on Platformsh\\Cli\\Local\\LocalApplication\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Cannot call method shouldMoveToRoot\\(\\) on Platformsh\\\\Cli\\\\Local\\\\LocalApplication\\|null\\.$#"
+			message: '#^Cannot call method shouldMoveToRoot\(\) on Platformsh\\Cli\\Local\\LocalApplication\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Parameter \\#1 \\$source of method Platformsh\\\\Cli\\\\Service\\\\Filesystem\\:\\:copyAll\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$source of method Platformsh\\Cli\\Service\\Filesystem\:\:copyAll\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Parameter \\#1 \\$target of method Platformsh\\\\Cli\\\\Service\\\\Filesystem\\:\\:symlink\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$target of method Platformsh\\Cli\\Service\\Filesystem\:\:symlink\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Local/BuildFlavor/BuildFlavorBase.php
 
 		-
-			message: "#^Cannot call method getSharedFileMounts\\(\\) on Platformsh\\\\Cli\\\\Local\\\\LocalApplication\\|null\\.$#"
+			message: '#^Cannot call method getSharedFileMounts\(\) on Platformsh\\Cli\\Local\\LocalApplication\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Local/BuildFlavor/Drupal.php
 
 		-
-			message: "#^Parameter \\#1 \\$source of method Platformsh\\\\Cli\\\\Service\\\\Filesystem\\:\\:symlinkAll\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$source of method Platformsh\\Cli\\Service\\Filesystem\:\:symlinkAll\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 2
 			path: src/Local/BuildFlavor/Drupal.php
 
 		-
-			message: "#^Access to an undefined property PhpParser\\\\Node\\\\Expr\\\\Error\\|PhpParser\\\\Node\\\\Expr\\\\Variable\\:\\:\\$name\\.$#"
+			message: '#^Strict comparison using \!\=\= between int and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: src/Local/LocalBuild.php
+
+		-
+			message: '#^Property Platformsh\\Cli\\Model\\AppConfig\:\:\$normalizedConfig in isset\(\) is not nullable nor uninitialized\.$#'
+			identifier: isset.initializedProperty
+			count: 1
+			path: src/Model/AppConfig.php
+
+		-
+			message: '#^Access to an undefined property PhpParser\\Node\\Expr\\Error\|PhpParser\\Node\\Expr\\Variable\:\:\$name\.$#'
+			identifier: property.notFound
 			count: 3
 			path: src/Rector/DependencyInjection.php
 
 		-
-			message: "#^Access to an undefined property PhpParser\\\\Node\\\\Expr\\|PhpParser\\\\Node\\\\Identifier\\:\\:\\$name\\.$#"
+			message: '#^Access to an undefined property PhpParser\\Node\\Expr\|PhpParser\\Node\\Identifier\:\:\$name\.$#'
+			identifier: property.notFound
 			count: 2
 			path: src/Rector/InjectCommandServicesRector.php
 
 		-
-			message: "#^Cannot access property \\$name on PhpParser\\\\Node\\\\Identifier\\|null\\.$#"
+			message: '#^Cannot access property \$name on PhpParser\\Node\\Identifier\|null\.$#'
+			identifier: property.nonObject
 			count: 2
 			path: src/Rector/InjectCommandServicesRector.php
 
 		-
-			message: "#^Parameter \\#2 \\$callable of method Rector\\\\Rector\\\\AbstractRector\\:\\:traverseNodesWithCallable\\(\\) expects callable\\(PhpParser\\\\Node\\)\\: \\(array\\<PhpParser\\\\Node\\>\\|int\\|PhpParser\\\\Node\\|null\\), Closure\\(PhpParser\\\\NodeAbstract\\)\\: \\(PhpParser\\\\Node\\\\Expr\\\\Assign\\|null\\) given\\.$#"
+			message: '#^Parameter \#2 \$callable of method Rector\\Rector\\AbstractRector\:\:traverseNodesWithCallable\(\) expects callable\(PhpParser\\Node\)\: \(array\<PhpParser\\Node\>\|int\|PhpParser\\Node\|null\), Closure\(PhpParser\\NodeAbstract\)\: \(PhpParser\\Node\\Expr\\Assign\|null\) given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Rector/InjectCommandServicesRector.php
 
 		-
-			message: "#^Access to an undefined property PhpParser\\\\Node\\\\Expr\\|PhpParser\\\\Node\\\\Identifier\\:\\:\\$name\\.$#"
+			message: '#^Access to an undefined property PhpParser\\Node\\Expr\|PhpParser\\Node\\Identifier\:\:\$name\.$#'
+			identifier: property.notFound
 			count: 1
 			path: src/Rector/NewServicesRector.php
 
 		-
-			message: "#^Cannot access property \\$name on PhpParser\\\\Node\\\\Identifier\\|null\\.$#"
+			message: '#^Cannot access property \$name on PhpParser\\Node\\Identifier\|null\.$#'
+			identifier: property.nonObject
 			count: 2
 			path: src/Rector/NewServicesRector.php
 
 		-
-			message: "#^Parameter \\#2 \\$callable of method Rector\\\\Rector\\\\AbstractRector\\:\\:traverseNodesWithCallable\\(\\) expects callable\\(PhpParser\\\\Node\\)\\: \\(array\\<PhpParser\\\\Node\\>\\|int\\|PhpParser\\\\Node\\|null\\), Closure\\(PhpParser\\\\NodeAbstract\\)\\: \\(PhpParser\\\\Node\\\\Expr\\\\MethodCall\\|null\\) given\\.$#"
+			message: '#^Parameter \#2 \$callable of method Rector\\Rector\\AbstractRector\:\:traverseNodesWithCallable\(\) expects callable\(PhpParser\\Node\)\: \(array\<PhpParser\\Node\>\|int\|PhpParser\\Node\|null\), Closure\(PhpParser\\NodeAbstract\)\: \(PhpParser\\Node\\Expr\\MethodCall\|null\) given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Rector/NewServicesRector.php
 
 		-
-			message: "#^Property PhpParser\\\\Node\\\\Expr\\\\MethodCall\\:\\:\\$args \\(array\\<PhpParser\\\\Node\\\\Arg\\|PhpParser\\\\Node\\\\VariadicPlaceholder\\>\\) does not accept array\\<PhpParser\\\\Node\\\\Arg\\>\\|string\\.$#"
+			message: '#^Property PhpParser\\Node\\Expr\\MethodCall\:\:\$args \(array\<PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder\>\) does not accept array\<PhpParser\\Node\\Arg\>\|string\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Rector/NewServicesRector.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Rector\\\\NewServicesRector\\:\\:\\$transforms type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Platformsh\\Cli\\Rector\\NewServicesRector\:\:\$transforms type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Rector/NewServicesRector.php
 
 		-
-			message: "#^Argument of an invalid type array\\<PhpParser\\\\Node\\\\Stmt\\>\\|null supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type array\<PhpParser\\Node\\Stmt\>\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: src/Rector/UnnecessaryServiceVariablesRector.php
 
 		-
-			message: "#^Cannot access property \\$name on PhpParser\\\\Node\\\\Identifier\\|null\\.$#"
+			message: '#^Cannot access property \$name on PhpParser\\Node\\Identifier\|null\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/Rector/UnnecessaryServiceVariablesRector.php
 
 		-
-			message: "#^Access to an undefined property PhpParser\\\\Node\\\\Arg\\|PhpParser\\\\Node\\\\VariadicPlaceholder\\:\\:\\$value\\.$#"
+			message: '#^Doing instanceof PHPStan\\Type\\ObjectType is error\-prone and deprecated\. Use Type\:\:isObject\(\) or Type\:\:getObjectClassNames\(\) instead\.$#'
+			identifier: phpstanApi.instanceofType
+			count: 1
+			path: src/Rector/UnnecessaryServiceVariablesRector.php
+
+		-
+			message: '#^Access to an undefined property PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder\:\:\$value\.$#'
+			identifier: property.notFound
 			count: 3
 			path: src/Rector/UseSelectorServiceRector.php
 
 		-
-			message: "#^Access to an undefined property PhpParser\\\\Node\\\\Expr\\|PhpParser\\\\Node\\\\Identifier\\:\\:\\$name\\.$#"
+			message: '#^Access to an undefined property PhpParser\\Node\\Expr\|PhpParser\\Node\\Identifier\:\:\$name\.$#'
+			identifier: property.notFound
 			count: 6
 			path: src/Rector/UseSelectorServiceRector.php
 
 		-
-			message: "#^Cannot access property \\$name on PhpParser\\\\Node\\\\Identifier\\|null\\.$#"
+			message: '#^Cannot access property \$name on PhpParser\\Node\\Identifier\|null\.$#'
+			identifier: property.nonObject
 			count: 2
 			path: src/Rector/UseSelectorServiceRector.php
 
 		-
-			message: "#^Parameter \\#2 \\$callable of method Rector\\\\Rector\\\\AbstractRector\\:\\:traverseNodesWithCallable\\(\\) expects callable\\(PhpParser\\\\Node\\)\\: \\(array\\<PhpParser\\\\Node\\>\\|int\\|PhpParser\\\\Node\\|null\\), Closure\\(PhpParser\\\\NodeAbstract\\)\\: \\(PhpParser\\\\Node\\\\Expr\\\\Assign\\|PhpParser\\\\Node\\\\Expr\\\\MethodCall\\|null\\) given\\.$#"
+			message: '#^Parameter \#2 \$callable of method Rector\\Rector\\AbstractRector\:\:traverseNodesWithCallable\(\) expects callable\(PhpParser\\Node\)\: \(array\<PhpParser\\Node\>\|int\|PhpParser\\Node\|null\), Closure\(PhpParser\\NodeAbstract\)\: \(PhpParser\\Node\\Expr\\Assign\|PhpParser\\Node\\Expr\\MethodCall\|null\) given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Rector/UseSelectorServiceRector.php
 
 		-
-			message: "#^Cannot call method fetchNextPage\\(\\) on Platformsh\\\\Client\\\\Model\\\\Collection\\|null\\.$#"
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\ApiResourceBase\:\:\$capabilities\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\ApiResourceBase\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 3
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Access to an undefined property Platformsh\\Client\\Model\\ApiResourceBase\:\:\$owner_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Selector\\Selector\:\:selectOrganization\(\) should return Platformsh\\Client\\Model\\Organization\\Organization but returns Platformsh\\Client\\Model\\ApiResourceBase\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Parameter \#1 \$id of method Platformsh\\Cli\\Service\\Api\:\:getEnvironment\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Parameter \#1 \$organization of method Platformsh\\Cli\\Service\\Api\:\:getOrganizationLabel\(\) expects Platformsh\\Client\\Model\\Organization\\Organization, Platformsh\\Client\\Model\\ApiResourceBase given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Parameter \#1 \$values of method Symfony\\Component\\Console\\Completion\\CompletionSuggestions\:\:suggestValues\(\) expects list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>, array\<Symfony\\Component\\Console\\Completion\\Suggestion\> given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Parameter \#1 \$values of method Symfony\\Component\\Console\\Completion\\CompletionSuggestions\:\:suggestValues\(\) expects list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>, array\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Parameter \#3 \$projectId of method Platformsh\\Cli\\Selector\\Selector\:\:selectProject\(\) expects string\|null, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Selector/Selector.php
+
+		-
+			message: '#^Cannot call method fetchNextPage\(\) on Platformsh\\Client\\Model\\Collection\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Service/AccessApi.php
 
 		-
-			message: "#^Cannot call method getData\\(\\) on Platformsh\\\\Client\\\\Model\\\\Collection\\|null\\.$#"
+			message: '#^Cannot call method getData\(\) on Platformsh\\Client\\Model\\Collection\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Service/AccessApi.php
 
 		-
-			message: "#^Cannot call method hasNextPage\\(\\) on Platformsh\\\\Client\\\\Model\\\\Collection\\|null\\.$#"
+			message: '#^Cannot call method hasNextPage\(\) on Platformsh\\Client\\Model\\Collection\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Service/AccessApi.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\ActivityMonitor\\:\\:indent\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Static property Platformsh\\Cli\\Service\\AccessApi\:\:\$userCache \(array\<string, Platformsh\\Client\\Model\\ProjectAccess\|Platformsh\\Client\\Model\\UserAccess\\ProjectUserAccess\|null\>\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: src/Service/AccessApi.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Service\\ActivityMonitor\:\:indent\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/ActivityMonitor.php
 
 		-
-			message: "#^Ternary operator condition is always false\\.$#"
+			message: '#^Ternary operator condition is always false\.$#'
+			identifier: ternary.alwaysFalse
 			count: 1
 			path: src/Service/ActivityMonitor.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\Api\\:\\:checkCanCreate\\(\\) should return array\\{can_create\\: bool, message\\: string, required_action\\: array\\{action\\: string, type\\: string\\}\\|null\\} but returns array\\.$#"
+			message: '#^Call to function is_array\(\) with array\<string, mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Service/Api.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\Api\\:\\:checkUserVerification\\(\\) should return array\\{state\\: bool, type\\: string\\} but returns array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\Api\:\:checkCanCreate\(\) should return array\{can_create\: bool, message\: string, required_action\: array\{action\: string, type\: string\}\|null\} but returns array\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/Api.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\Api\\:\\:getMyAccount\\(\\) should return array\\{id\\: string, username\\: string, email\\: string, first_name\\: string, last_name\\: string, display_name\\: string, phone_number_verified\\: bool\\} but returns non\\-empty\\-array\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\Api\:\:checkUserVerification\(\) should return array\{state\: bool, type\: string\} but returns array\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/Api.php
 
 		-
-			message: "#^Parameter \\#1 \\$project of method Platformsh\\\\Cli\\\\Service\\\\Api\\:\\:supportsGuaranteedCPU\\(\\) expects Platformsh\\\\Client\\\\Model\\\\Project, Platformsh\\\\Client\\\\Model\\\\Project\\|null given\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\Api\:\:getMyAccount\(\) should return array\{id\: string, username\: string, email\: string, first_name\: string, last_name\: string, display_name\: string, phone_number_verified\: bool\} but returns non\-empty\-array\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/Api.php
 
 		-
-			message: "#^Parameter \\#1 \\$storage of method Platformsh\\\\Client\\\\Session\\\\Session\\:\\:setStorage\\(\\) expects Platformsh\\\\Client\\\\Session\\\\Storage\\\\SessionStorageInterface, Platformsh\\\\Client\\\\Session\\\\Storage\\\\SessionStorageInterface\\|null given\\.$#"
+			message: '#^Parameter \#1 \$project of method Platformsh\\Cli\\Service\\Api\:\:supportsGuaranteedCPU\(\) expects Platformsh\\Client\\Model\\Project, Platformsh\\Client\\Model\\Project\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Service/Api.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\CurlCli\\:\\:run\\(\\) should return int but returns int\\|null\\.$#"
+			message: '#^Parameter \#1 \$storage of method Platformsh\\Client\\Session\\Session\:\:setStorage\(\) expects Platformsh\\Client\\Session\\Storage\\SessionStorageInterface, Platformsh\\Client\\Session\\Storage\\SessionStorageInterface\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Service/Api.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 2
+			path: src/Service/Api.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: src/Service/Api.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between \*NEVER\* and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Service/Api.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Service\\Config\:\:getProxies\(\) should return array\{https\?\: string, http\?\: string\} but returns array\{\}\|array\{https\?\: string\|false, http\?\: string\|false\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Service/Config.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Service\\CurlCli\:\:run\(\) should return int but returns int\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/CurlCli.php
 
 		-
-			message: "#^Parameter \\#2 \\$appName of method Platformsh\\\\Cli\\\\Service\\\\Api\\:\\:getSiteUrl\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#2 \$appName of method Platformsh\\Cli\\Service\\Api\:\:getSiteUrl\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Service/Drush.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\Filesystem\\:\\:fixTarPath\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\Filesystem\:\:fixTarPath\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/Filesystem.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\Filesystem\\:\\:remove\\(\\) has parameter \\$files with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\Filesystem\:\:remove\(\) has parameter \$files with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Service/Filesystem.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\Filesystem\\:\\:unprotect\\(\\) has parameter \\$files with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\Filesystem\:\:unprotect\(\) has parameter \$files with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Service/Filesystem.php
 
 		-
-			message: "#^Parameter \\#7 \\$uri of method Platformsh\\\\Cli\\\\Service\\\\Git\\:\\:execute\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#7 \$uri of method Platformsh\\Cli\\Service\\Git\:\:execute\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Service/Git.php
 
 		-
-			message: "#^Parameter \\#2 \\$sha of method Platformsh\\\\Cli\\\\Service\\\\GitDataApi\\:\\:getCommitByShaHash\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#2 \$sha of method Platformsh\\Cli\\Service\\GitDataApi\:\:getCommitByShaHash\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Service/GitDataApi.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:head\\(\\)\\.$#"
+			message: '#^Strict comparison using \=\=\= between string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Service/GitDataApi.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:head\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Service/Identifier.php
 
 		-
-			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:writeln\\(\\) expects iterable\\|string, string\\|null given\\.$#"
+			message: '#^Offset int\<0, max\>\|false might not exist on list\<string\>\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: src/Service/QuestionHelper.php
+
+		-
+			message: '#^Offset ''host'' might not exist on non\-empty\-array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: src/Service/Relationships.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Service\\RemoteEnvVars\:\:getEnvVar\(\) should return string but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Service/RemoteEnvVars.php
+
+		-
+			message: '#^Parameter \#1 \$messages of method Symfony\\Component\\Console\\Output\\OutputInterface\:\:writeln\(\) expects iterable\|string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Service/SelfUpdater.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\Shell\\:\\:runProcess\\(\\) should return int but returns int\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\Shell\:\:runProcess\(\) should return int but returns int\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/Shell.php
 
 		-
-			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:write\\(\\) expects iterable\\|string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$messages of method Symfony\\Component\\Console\\Output\\OutputInterface\:\:write\(\) expects iterable\|string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Service/Shell.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\Ssh\\:\\:getHost\\(\\) should return string\\|false but returns string\\|false\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\Ssh\:\:getHost\(\) should return string\|false but returns string\|false\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/Ssh.php
 
 		-
-			message: "#^Argument of an invalid type array\\<Platformsh\\\\Cli\\\\Tunnel\\\\Tunnel\\>\\|null supplied for foreach, only iterables are supported\\.$#"
+			message: '#^PHPDoc tag @var with type array\<string\>\|string is not subtype of native type non\-empty\-array\|float\|int\<min, \-1\>\|int\<1, max\>\|non\-falsy\-string\|true\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: src/Service/SshConfig.php
+
+		-
+			message: '#^Argument of an invalid type array\<Platformsh\\Cli\\Tunnel\\Tunnel\>\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: src/Service/TunnelManager.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Service\\\\TunnelManager\\:\\:getTunnels\\(\\) should return array\\<Platformsh\\\\Cli\\\\Tunnel\\\\Tunnel\\> but returns array\\<Platformsh\\\\Cli\\\\Tunnel\\\\Tunnel\\>\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Service\\TunnelManager\:\:getTunnels\(\) should return array\<Platformsh\\Cli\\Tunnel\\Tunnel\> but returns array\<Platformsh\\Cli\\Tunnel\\Tunnel\>\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Service/TunnelManager.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Util\\\\Csv\\:\\:formatCell\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Property Platformsh\\Cli\\Service\\TunnelManager\:\:\$tunnels \(array\<Platformsh\\Cli\\Tunnel\\Tunnel\>\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: src/Service/TunnelManager.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Service/VariableCommandUtil.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\SshCert\\Certificate\:\:inlineAccess\(\) should return array\<string, mixed\> but returns array\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/SshCert/Certificate.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\SshCert\\Certificate\:\:tokenClaims\(\) should return array\{auth_time\?\: int, amr\?\: array\<string\>, grant\?\: string, scp\?\: array\<string\>, act\?\: array\{sub\?\: string, src\?\: string\}\} but returns array\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/SshCert/Certificate.php
+
+		-
+			message: '#^Method Platformsh\\Cli\\Util\\Csv\:\:formatCell\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Util/Csv.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Util/OsUtil.php
 
 		-
-			message: "#^Method Platformsh\\\\Cli\\\\Util\\\\PlainFormat\\:\\:formatCell\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Platformsh\\Cli\\Util\\PlainFormat\:\:formatCell\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Util/PlainFormat.php
 
 		-
-			message: "#^Dead catch \\- InvalidArgumentException is never thrown in the try block\\.$#"
+			message: '#^Call to function is_array\(\) with array\<mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Util/YamlParser.php
+
+		-
+			message: '#^Parameter \#1 \$array \(array\{''dev%%\:v'', ''prod\:admin''\}\|array\{''development\:viewer'', ''nonexistent\:viewer'', ''stg\:admin''\}\|array\{''staging\:viewer'', ''stg\:admin'', ''viewer''\}\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
 			count: 1
 			path: tests/Command/User/UserAddCommandTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$parentDir of method Platformsh\\\\Cli\\\\Tests\\\\Local\\\\BuildFlavor\\\\BuildFlavorTestBase\\:\\:createTempDir\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$parentDir of method Platformsh\\Cli\\Tests\\Local\\BuildFlavor\\BuildFlavorTestBase\:\:createTempDir\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/Local/BuildFlavor/BuildFlavorTestBase.php
 
 		-
-			message: "#^Cannot call method getTreeId\\(\\) on Platformsh\\\\Cli\\\\Local\\\\LocalBuild\\|null\\.$#"
+			message: '#^Cannot call method getTreeId\(\) on Platformsh\\Cli\\Local\\LocalBuild\|null\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: tests/Local/LocalBuildTest.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Tests\\\\Local\\\\LocalBuildTest\\:\\:\\$localBuild \\(Platformsh\\\\Cli\\\\Local\\\\LocalBuild\\|null\\) does not accept object\\.$#"
+			message: '#^Property Platformsh\\Cli\\Tests\\Local\\LocalBuildTest\:\:\$localBuild \(Platformsh\\Cli\\Local\\LocalBuild\|null\) does not accept object\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: tests/Local/LocalBuildTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$parentDir of method Platformsh\\\\Cli\\\\Tests\\\\Service\\\\DrushServiceTest\\:\\:createTempDir\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Property Platformsh\\Cli\\Tests\\Local\\LocalBuildTest\:\:\$localBuild \(Platformsh\\Cli\\Local\\LocalBuild\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Local/LocalBuildTest.php
+
+		-
+			message: '#^Parameter \#1 \$parentDir of method Platformsh\\Cli\\Tests\\Service\\DrushServiceTest\:\:createTempDir\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/Service/DrushServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$parentDir of method Platformsh\\\\Cli\\\\Tests\\\\Service\\\\FilesystemServiceTest\\:\\:createTempDir\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$parentDir of method Platformsh\\Cli\\Tests\\Service\\FilesystemServiceTest\:\:createTempDir\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/Service/FilesystemServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$parentDir of method Platformsh\\\\Cli\\\\Tests\\\\Service\\\\GitServiceTest\\:\\:createTempDir\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$parentDir of method Platformsh\\Cli\\Tests\\Service\\GitServiceTest\:\:createTempDir\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/Service/GitServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$objectOrMethod of class ReflectionMethod constructor expects object\\|string, Platformsh\\\\Cli\\\\Service\\\\Ssh\\|null given\\.$#"
+			message: '#^Parameter \#1 \$objectOrMethod of class ReflectionMethod constructor expects object\|string, Platformsh\\Cli\\Service\\Ssh\|null given\.$#'
+			identifier: argument.type
 			count: 2
 			path: tests/Service/SshTest.php
 
 		-
-			message: "#^Property Platformsh\\\\Cli\\\\Tests\\\\Service\\\\SshTest\\:\\:\\$ssh \\(Platformsh\\\\Cli\\\\Service\\\\Ssh\\|null\\) does not accept object\\.$#"
+			message: '#^Property Platformsh\\Cli\\Tests\\Service\\SshTest\:\:\$ssh \(Platformsh\\Cli\\Service\\Ssh\|null\) does not accept object\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: tests/Service/SshTest.php
+
+		-
+			message: '#^Property Platformsh\\Cli\\Tests\\Service\\SshTest\:\:\$ssh \(Platformsh\\Cli\\Service\\Ssh\|null\) is never assigned null so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Service/SshTest.php
+
+		-
+			message: '#^Property Platformsh\\Cli\\Tests\\Util\\TimezoneUtilTest\:\:\$originalIni \(bool\|string\) is never assigned bool so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Util/TimezoneUtilTest.php

--- a/legacy/phpstan-stubs/Activity.stub
+++ b/legacy/phpstan-stubs/Activity.stub
@@ -21,7 +21,7 @@ namespace Platformsh\Client\Model;
  * @property-read string|null $completed_at
  * @property-read string|null $cancelled_at
  * @property-read string|null $expires_at
- * @property-read array       $parameters
+ * @property-read array<string, mixed> $parameters
  * @property-read string      $project
  * @property-read string|null $integration
  * @property-read string      $state
@@ -29,9 +29,9 @@ namespace Platformsh\Client\Model;
  * @property-read string      $type
  * @property-read string|null $description
  * @property-read string|null $text
- * @property-read array       $payload
- * @property-read array       $timings
- * @property-read array       $commands
+ * @property-read array<string, mixed> $payload
+ * @property-read array<string, mixed> $timings
+ * @property-read array<string, mixed> $commands
  */
 class Activity
 {

--- a/legacy/rector.php
+++ b/legacy/rector.php
@@ -2,15 +2,12 @@
 
 declare(strict_types=1);
 
-use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Rector\InjectCommandServicesRector;
 use Platformsh\Cli\Rector\NewServicesRector;
 use Platformsh\Cli\Rector\UnnecessaryServiceVariablesRector;
 use Platformsh\Cli\Rector\UseSelectorServiceRector;
 use Rector\Config\RectorConfig;
 use Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector;
-use Rector\Transform\Rector\MethodCall\MethodCallToPropertyFetchRector;
-use Rector\Transform\ValueObject\MethodCallToPropertyFetch;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -25,12 +22,4 @@ return RectorConfig::configure()
         UnnecessaryServiceVariablesRector::class,
     ])
     ->withImportNames(importShortClasses: false, removeUnusedImports: true)
-    ->withConfiguredRule(
-        MethodCallToPropertyFetchRector::class,
-        [new MethodCallToPropertyFetch(CommandBase::class, 'api', 'api')],
-    )
-    ->withConfiguredRule(
-        MethodCallToPropertyFetchRector::class,
-        [new MethodCallToPropertyFetch(CommandBase::class, 'config', 'config')],
-    )
 ;


### PR DESCRIPTION
## What

Upgrades the legacy PHP CLI's static analysis to PHPStan 2.x (2.2.2), keeping level 8.

## Changes

- Make `phpstan/phpstan` an explicit dev dependency at `^2.1`. It was previously pulled in transitively at 1.x via `rector/rector`.
- Bump `rector/rector` to `^2.0`. Rector `^1.2` requires phpstan `^1.12.5`, which conflicts with phpstan 2.x, so rector has to move too.
- Rector 2.x removed the built-in `MethodCallToPropertyFetchRector`, so drop the two configured uses of it from `rector.php`. Those were one-time migration helpers (`$this->api()`/`$this->config()` to property access) and that migration is complete. The custom rules in `src/Rector` are unchanged and still run under rector 2.x.
- Type the loose JSON payload properties in `phpstan-stubs/Activity.stub` as `array<string, mixed>`, since PHPStan 2.x requires value types on iterables.
- Regenerate `phpstan-baseline.neon` for the stricter level-8 rules added in PHPStan 2.x.

## Verification

- `make lint` (php-cs-fixer + phpstan 2.x): passes.
- `rector process --dry-run`: config loads and custom rules run.

> [!NOTE]
> One pre-existing legacy test failure is unrelated to this change: `WelcomeCommandTest::testWelcomeOnLocalContainer` errors with "Configuration not defined: detection.git_remote_name". It fails identically on `main` without these changes (verified by stashing the diff), so it is left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)